### PR TITLE
Added support of coursehunter.net

### DIFF
--- a/src/config/sites.js
+++ b/src/config/sites.js
@@ -221,6 +221,12 @@ const sites = () => {
       match: /^disk.yandex.ru$/,
       selector: "yaplayertag > div:nth-of-type(1)",
     },
+    {
+      host: "coursehunter",
+      url: "https://coursehunter.net/",
+      match: /^(vss\d\.)?coursehunter.net$/,
+      selector: null,
+    },
   ];
 };
 

--- a/src/headers.json
+++ b/src/headers.json
@@ -96,7 +96,8 @@
     "*://peertube.tmp.rcp.tf/*",
     "*://geo.dailymotion.com/*",
     "*://trovo.live/*",
-    "*://disk.yandex.ru/i/*"
+    "*://disk.yandex.ru/i/*",
+    "*://*.coursehunter.net/*"
   ],
   "require": [
     "https://cdn.jsdelivr.net/npm/protobufjs/dist/light/protobuf.min.js",

--- a/src/index.js
+++ b/src/index.js
@@ -2195,6 +2195,13 @@ async function main() {
         site.url = window.location.origin;
       }
 
+      if (site.host === "coursehunter") {
+        site.url = (
+          video.getAttribute("src") ||
+          video.querySelector("source").getAttribute("src")
+        ).match(/.+\/\/.+\.net/g)[0];
+      }
+
       if (!videosWrappers.has(video)) {
         videosWrappers.set(video, new VideoHandler(video, container, site));
         break;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -249,6 +249,12 @@ const getVideoId = (service, video) => {
     case "yandexdisk": {
       return url.pathname.match(/\/[i|s|d]\/([^/]+)/)?.[1];
     }
+    case "coursehunter": {
+      return (
+        video.getAttribute("src") ||
+        video.querySelector("source").getAttribute("src")
+      ).replace(/.+\/\/.+\.net/g, "");
+    }
     default:
       return false;
   }


### PR DESCRIPTION
Добавил поддержку coursehunter.net. Большинство курсов закрыты подпиской, но видео доступны некоторое время по прямым ссылкам, без аутентификации, поэтому переводятся спокойно.
Учел поддержку переводчика как на странице с видео, так и при открытии видео по прямой ссылке.
Кнопка переводчика появляется после нажатия на play, т.к. до этого момента никакого видео на странице ещё нет.

Ссылка на видео выглядит так:
`https://vss[VSS_ID].coursehunter.net/s/HASH/COURSE_NAME/VIDEO_NAME.mp4`

Неприятный момент: **HASH** меняется при каждом обновлении страницы. Т.е. ссылка в целом новая, и перевод будет запускаться заново, вместо того чтобы подтягиваться из кэша Яндекса. Но не считаю это прям проблемой. Скорее неудобством. По прямой ссылке соответственно перевод подтянется мгновенно.