### PR TITLE
file:// не должен переводиться 

### DIFF
--- a/src/headers.json
+++ b/src/headers.json
@@ -107,6 +107,9 @@
     "*://*.youku.com/*",
     "*://*/*.mp4*"
   ],
+  "exclude": [
+    "file://*/*.mp4*"
+  ],
   "require": [
     "https://cdn.jsdelivr.net/npm/protobufjs/dist/light/protobuf.min.js",
     "https://cdn.jsdelivr.net/npm/hls.js/dist/hls.light.min.js"

--- a/src/index.js
+++ b/src/index.js
@@ -1278,6 +1278,11 @@ class VideoHandler {
       this.container.draggable = false;
     }
 
+    addExtraEventListener(this.video, "emptied", () => {
+      debug.log("lipsync mode is emptied");
+      this.stopTranslation();
+    });
+
     addExtraEventListener(this.video, "progress", async () => {
       if (
         !this.videoData.videoId ||
@@ -1642,10 +1647,6 @@ class VideoHandler {
     if (mode == "playing") {
       debug.log("lipsync mode is playing");
       this.audio.play();
-    }
-    if (mode == "emptied") {
-      debug.log("lipsync mode is emptied");
-      this.stopTranslation();
     }
   }
 


### PR DESCRIPTION
"*://*/*.mp4*" позволяет запускать скрипт для file://, а переводить их нельзя. Также вернул addExtraEventListener, emptied в lipsync работает некорректно.