### PR TITLE
Перенос Tone.js и исправление громкости

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "lit": "^3.2.1",
         "requestidlecallback-polyfill": "^1.0.2",
         "soundtouchjs": "^0.1.30",
-        "tone": "^15.0.4",
         "vot.js": "^1.3.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lit": "^3.2.1",
     "requestidlecallback-polyfill": "^1.0.2",
     "soundtouchjs": "^0.1.30",
-    "tone": "^15.0.4",
     "vot.js": "^1.3.4"
   }
 }

--- a/src/headers.json
+++ b/src/headers.json
@@ -69,6 +69,7 @@
     "https://cdn.jsdelivr.net/npm/protobufjs/dist/light/protobuf.min.js",
     "https://cdn.jsdelivr.net/npm/hls.js/dist/hls.light.min.js",
     "https://cdn.jsdelivr.net/npm/animejs@3/lib/anime.min.js",
+    "https://cdn.jsdelivr.net/npm/tone/build/Tone.min.js",
     "https://gist.githubusercontent.com/ilyhalight/6eb5bb4dffc7ca9e3c57d6933e2452f3/raw/7ab38af2228d0bed13912e503bc8a9ee4b11828d/gm-addstyle-polyfill.js"
   ],
   "connect": [

--- a/src/index.js
+++ b/src/index.js
@@ -191,8 +191,8 @@ class VideoHandler {
       await this.updateTranslationErrorMsg(
         res.remainingTime > 0
           ? secsToStrTime(res.remainingTime)
-          : res.message ??
-              localizationProvider.get("translationTakeFewMinutes"),
+          : (res.message ??
+              localizationProvider.get("translationTakeFewMinutes")),
       );
     } catch (err) {
       console.error("[VOT] Failed to translate video", err);
@@ -2176,7 +2176,6 @@ class VideoHandler {
     if (this.volumeOnStart) {
       this.setVideoVolume(this.volumeOnStart);
     }
-    this.volumeOnStart = "";
     clearInterval(this.streamPing);
     clearTimeout(this.autoRetry);
     this.hls?.destroy();
@@ -2322,10 +2321,6 @@ class VideoHandler {
       console.log(`[VOT] Audio proxied via ${audioUrl}`);
     }
 
-    if (!this.volumeOnStart) {
-      this.volumeOnStart = this.getVideoVolume();
-    }
-
     this.setupAudioSettings();
     if (this.site.host === "twitter") {
       document
@@ -2355,6 +2350,7 @@ class VideoHandler {
     debug.log("Run videoValidator");
     this.videoValidator();
     this.setLoadingBtn(true);
+    this.volumeOnStart = this.getVideoVolume();
 
     if (isStream) {
       let translateRes = await this.translateStreamImpl(
@@ -2539,11 +2535,9 @@ class VideoHandler {
       this.container.append(this.votButton.container, this.votMenu.container);
     }
 
-    await Promise.all([
-      (this.videoData = await this.getVideoData()),
-      this.updateSubtitles(),
-      (this.translateToLang = this.data.responseLanguage ?? "ru"),
-    ]);
+    this.videoData = await this.getVideoData();
+    await this.updateSubtitles();
+    this.translateToLang = this.data.responseLanguage ?? "ru";
     this.setSelectMenuValues(
       this.videoData.detectedLanguage,
       this.videoData.responseLanguage,

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -1,5 +1,3 @@
-import * as Tone from "tone";
-
 import debug from "./debug";
 
 import { VideoHandler } from "../index.js";


### PR DESCRIPTION
1. Переместил Tone.js в headers.js для уменьшения общего веса скрипта.
2. Перенес this.volumeOnStart для корректного восстановления громкости при отключении перевода на стримах.
3. Убрал Promise.all, так как в данном контексте он лишний.

Примечание: был обнаружен баг с трансляциями — при увеличении скорости видео аудио исчезает.