### PR TITLE
Added safe check for undefined videoData before accessing videoId

### DIFF
--- a/dist/vot.user.js
+++ b/dist/vot.user.js
@@ -16789,14 +16789,11 @@ class VideoHandler {
       await this.setCanPlay();
     });
     addExtraEventListener(this.video, "emptied", async () => {
-      if (
-        this.video.src &&
-        (await getVideoID(this.site, {
-          fetchFn: GM_fetch,
-          video: this.video,
-        })) === this.videoData.videoId
-      )
-        return;
+      const videoId = await getVideoID(this.site, {
+        fetchFn: GM_fetch,
+        video: this.video,
+      });
+      if (this.video.src && this.videoData && videoId === this.videoData.videoId) return;
       utils_debug.log("lipsync mode is emptied");
       this.videoData = undefined;
       this.stopTranslation();
@@ -16820,13 +16817,11 @@ class VideoHandler {
    * Called when the video can play.
    */
   async setCanPlay() {
-    if (
-      (await getVideoID(this.site, {
-        fetchFn: GM_fetch,
-        video: this.video,
-      })) === this.videoData.videoId
-    )
-      return;
+    const videoId = await getVideoID(this.site, {
+      fetchFn: GM_fetch,
+      video: this.video,
+    });
+    if (this.video.src && this.videoData && videoId === this.videoData.videoId) return;
     await this.handleSrcChanged();
     await this.autoTranslate();
     utils_debug.log("lipsync mode is canplay");

--- a/src/index.js
+++ b/src/index.js
@@ -979,12 +979,14 @@ class VideoHandler {
       await this.setCanPlay();
     });
     addExtraEventListener(this.video, "emptied", async () => {
+      const videoId = await getVideoID(this.site, {
+        fetchFn: GM_fetch,
+        video: this.video,
+      });
       if (
         this.video.src &&
-        (await getVideoID(this.site, {
-          fetchFn: GM_fetch,
-          video: this.video,
-        })) === this.videoData.videoId
+        this.videoData &&
+        videoId === this.videoData.videoId
       )
         return;
       debug.log("lipsync mode is emptied");
@@ -1010,12 +1012,11 @@ class VideoHandler {
    * Called when the video can play.
    */
   async setCanPlay() {
-    if (
-      (await getVideoID(this.site, {
-        fetchFn: GM_fetch,
-        video: this.video,
-      })) === this.videoData.videoId
-    )
+    const videoId = await getVideoID(this.site, {
+      fetchFn: GM_fetch,
+      video: this.video,
+    });
+    if (this.video.src && this.videoData && videoId === this.videoData.videoId)
       return;
     await this.handleSrcChanged();
     await this.autoTranslate();


### PR DESCRIPTION
Кароче, Нам нужно правильно проверять videoData перед тем, как с него доставать какие-то данные.

Этот PL не полностью устраняет это дерьмо, но оно больше не будет оставаться на экране постоянно и кнопка перевода не останется "замороженной".
Ошибка будет отображаться лишь на короткое время, после чего всё снова будет работать нормально.
++ сделал небольшой рефакторинг.

## ДО (для перезапуска перевода нужно перезагрузить страницу):
https://github.com/user-attachments/assets/5bdb3ef2-cb92-4016-ad7d-aa03b30027b8

## ПОСЛЕ
https://github.com/user-attachments/assets/4481ab08-6ae9-4261-a9e0-25a0989bc085



