### PR TITLE
Fix playback and download regressions

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -25,6 +25,7 @@ export const foswlyTranslateUrl = "https://translate-backend.transly.eu.cc/v2"; 
 export const detectRustServerUrl =
   "https://rust-server-531j.onrender.com/detect";
 export const authServerUrl = "https://rust-server-531j.onrender.com";
+export const authLoginUrl = `${authServerUrl}/v1/auth/handle`;
 export const avatarServerUrl = "https://avatars.mds.yandex.net/get-yapic";
 
 const repoPath = "ilyhalight/voice-over-translation";

--- a/src/core/videoLifecycleHost.ts
+++ b/src/core/videoLifecycleHost.ts
@@ -82,7 +82,13 @@ export function createVideoLifecycleHost(
       return self().videoData;
     },
     set videoData(value: any) {
-      self().videoData = value;
+      const handler = self();
+      const previousVideoId = handler.videoData?.videoId;
+      const nextVideoId = value?.videoId;
+      if (previousVideoId !== nextVideoId) {
+        handler.downloadTranslation = null;
+      }
+      handler.videoData = value;
     },
     get actionsAbortController() {
       return self().actionsAbortController;

--- a/src/core/videoManager.ts
+++ b/src/core/videoManager.ts
@@ -33,6 +33,7 @@ const FORCED_DETECTED_LANGUAGE_BY_HOST: Record<string, RequestLang> = {
 };
 
 const YT_VOLUME_NOW_SELECTOR = ".ytp-volume-panel [aria-valuenow]";
+const YT_PLAYER_VOLUME_STORAGE_KEY = "yt-player-volume";
 const MIN_DETECT_TEXT_LENGTH = 35;
 const MAX_SHARED_LANGUAGE_STATES = 500;
 const REQUEST_LANG_SET = new Set<RequestLang>(
@@ -64,6 +65,20 @@ type ResolveDetectedLanguageOptions = {
 type ResolveDetectedLanguageResult = {
   detectedLanguage: RequestLang;
   cacheLanguage?: ResolvedRequestLang;
+};
+
+type YoutubeVolumeStorageSnapshot = {
+  storage: Storage;
+  value: string | null;
+};
+
+type YoutubePlayerWithMute = {
+  mute?: () => void;
+  unMute?: () => void;
+};
+
+type ExternalPlaybackWriteOptions = {
+  preserveYoutubeVolumeStorage?: boolean;
 };
 
 /**
@@ -166,6 +181,50 @@ function resolveYoutubeDetectedLanguageFromSubtitles(
   };
 
   return pickLanguage(true) ?? pickLanguage(false);
+}
+
+function getYoutubeVolumeStorageSnapshot(): YoutubeVolumeStorageSnapshot | null {
+  try {
+    const storage = globalThis.localStorage;
+    return {
+      storage,
+      value: storage.getItem(YT_PLAYER_VOLUME_STORAGE_KEY),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function restoreYoutubeVolumeStorageSnapshot(
+  snapshot: YoutubeVolumeStorageSnapshot | null,
+): void {
+  if (!snapshot) {
+    return;
+  }
+
+  try {
+    if (snapshot.value === null) {
+      snapshot.storage.removeItem(YT_PLAYER_VOLUME_STORAGE_KEY);
+    } else {
+      snapshot.storage.setItem(YT_PLAYER_VOLUME_STORAGE_KEY, snapshot.value);
+    }
+  } catch {
+    // localStorage can be blocked in some frames. Playback control should still work.
+  }
+}
+
+function preserveYoutubeVolumeStorage<T>(action: () => T): T {
+  const snapshot = getYoutubeVolumeStorageSnapshot();
+  const restoreSnapshot = () => restoreYoutubeVolumeStorageSnapshot(snapshot);
+
+  try {
+    return action();
+  } finally {
+    restoreSnapshot();
+    if (snapshot && typeof globalThis.setTimeout === "function") {
+      globalThis.setTimeout(restoreSnapshot, 0);
+    }
+  }
 }
 
 export async function resolveDetectedLanguageForVideo(
@@ -412,7 +471,7 @@ export class VOTVideoManager {
     } satisfies RuntimeVideoData;
 
     if (sharedLanguageState.lastLoggedDetectedLanguage !== detectedLanguage) {
-      console.log("[VOT] Detected language:", detectedLanguage);
+      debug.log("[VOT] Detected language:", detectedLanguage);
       sharedLanguageState.lastLoggedDetectedLanguage = detectedLanguage;
     }
     return videoData;
@@ -473,7 +532,7 @@ export class VOTVideoManager {
   /**
    * Sets the video volume
    */
-  setVideoVolume(volume: number) {
+  setVideoVolume(volume: number, options: ExternalPlaybackWriteOptions = {}) {
     const snapped = snapVolume01(volume);
 
     if (!isExternalVolumeHost(this.videoHandler.site.host)) {
@@ -485,7 +544,11 @@ export class VOTVideoManager {
     // Do NOT use a truthy check here, or setting volume to 0 (0%) will be treated
     // as a failure.
     try {
-      const result = YoutubeHelper.setVolume(snapped) as unknown;
+      const setExternalVolume = () =>
+        YoutubeHelper.setVolume(snapped) as unknown;
+      const result = options.preserveYoutubeVolumeStorage
+        ? preserveYoutubeVolumeStorage(setExternalVolume)
+        : setExternalVolume();
       const ok =
         (typeof result === "boolean" && result) ||
         (typeof result === "number" && Number.isFinite(result));
@@ -498,13 +561,42 @@ export class VOTVideoManager {
     return this;
   }
 
+  setVideoMuted(muted: boolean, options: ExternalPlaybackWriteOptions = {}) {
+    if (isExternalVolumeHost(this.videoHandler.site.host)) {
+      const player = YoutubeHelper.getPlayer() as
+        | (YoutubePlayerWithMute & Element)
+        | null;
+      const method = muted ? player?.mute : player?.unMute;
+      if (typeof method === "function") {
+        try {
+          const setExternalMuted = () => method.call(player);
+          if (options.preserveYoutubeVolumeStorage) {
+            preserveYoutubeVolumeStorage(setExternalMuted);
+          } else {
+            setExternalMuted();
+          }
+        } catch {
+          // ignore - fall back to the HTMLMediaElement muted flag below.
+        }
+      }
+    }
+
+    if (this.videoHandler.video) {
+      this.videoHandler.video.muted = muted;
+    }
+
+    return this;
+  }
+
   /**
    * Checks if the video is muted
    */
   isMuted() {
-    return isExternalVolumeHost(this.videoHandler.site.host)
-      ? YoutubeHelper.isMuted()
-      : this.videoHandler.video?.muted;
+    if (!isExternalVolumeHost(this.videoHandler.site.host)) {
+      return this.videoHandler.video?.muted;
+    }
+
+    return YoutubeHelper.isMuted() || Boolean(this.videoHandler.video?.muted);
   }
 
   /**
@@ -539,7 +631,7 @@ export class VOTVideoManager {
     const langPairLogKey = `${normalizedFrom}->${to}`;
     const sharedLanguageState = getSharedLanguageState(videoData.videoId);
     if (sharedLanguageState.lastLoggedLangPair !== langPairLogKey) {
-      console.log(`[VOT] Set translation from ${normalizedFrom} to ${to}`);
+      debug.log(`[VOT] Set translation from ${normalizedFrom} to ${to}`);
       sharedLanguageState.lastLoggedLangPair = langPairLogKey;
     }
     videoData.detectedLanguage = normalizedFrom;

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,11 @@ type InternalVideoVolumeSetHistoryEntry = {
   suppressMs: number;
 };
 
+type DownloadTranslationState = {
+  url: string;
+  videoId: string;
+};
+
 /*─────────────────────────────────────────────────────────────*/
 /*                        Main class: VideoHandler             */
 /*  Composes the helper classes and retains full functionality.  */
@@ -160,7 +165,7 @@ export class VideoHandler {
    * before the first request resolves.
    */
   subtitlesLoadPromises = new Map<string, Promise<any[]>>();
-  downloadTranslationUrl: string | null = null;
+  downloadTranslation: DownloadTranslationState | null = null;
 
   isRefreshingTranslation = false;
 
@@ -168,6 +173,7 @@ export class VideoHandler {
   // streamPing?: ReturnType<typeof setInterval>;
   votOpts?: Record<string, unknown>;
   volumeOnStart?: number;
+  autoVolumeMutedOnStart?: boolean;
 
   /**
    * syncVolume (link translation and video volume) runtime state.
@@ -961,7 +967,10 @@ export class VideoHandler {
    */
   setVideoVolume(
     volume: number,
-    options: { suppressSyncMs?: number } = {},
+    options: {
+      preserveYoutubeVolumeStorage?: boolean;
+      suppressSyncMs?: number;
+    } = {},
   ): this {
     const snapped = snapVolume01(volume);
     const suppressSyncMs =
@@ -993,7 +1002,19 @@ export class VideoHandler {
       );
     }
 
-    this.videoManager.setVideoVolume(snapped);
+    this.videoManager.setVideoVolume(snapped, {
+      preserveYoutubeVolumeStorage: options.preserveYoutubeVolumeStorage,
+    });
+    return this;
+  }
+
+  setVideoMuted(
+    muted: boolean,
+    options: { preserveYoutubeVolumeStorage?: boolean } = {},
+  ): this {
+    this.videoManager.setVideoMuted(muted, {
+      preserveYoutubeVolumeStorage: options.preserveYoutubeVolumeStorage,
+    });
     return this;
   }
 
@@ -1163,7 +1184,7 @@ export class VideoHandler {
           overlayView.downloadTranslationButton.hidden = true;
         }
       }
-      this.downloadTranslationUrl = null;
+      this.downloadTranslation = null;
       this.longWaitingResCount = 0;
       this.hadAsyncWait = false;
       this.transformBtn("none", localizationProvider.get("translateVideo"));
@@ -1178,6 +1199,7 @@ export class VideoHandler {
 
       stopSmartVolumeDuckingImpl(this, { restoreVolume });
       this.volumeOnStart = undefined;
+      this.autoVolumeMutedOnStart = undefined;
       if (this.autoRetry !== undefined) {
         clearTimeout(this.autoRetry);
         this.autoRetry = undefined;
@@ -1370,11 +1392,14 @@ export class VideoHandler {
       if (overlayView.downloadTranslationButton) {
         overlayView.downloadTranslationButton.hidden = false;
       }
-      this.downloadTranslationUrl = audioUrl;
+      this.downloadTranslation = {
+        url: audioUrl,
+        videoId: this.videoData.videoId,
+      };
     }
     debug.log(
-      "afterUpdateTranslation downloadTranslationUrl",
-      this.downloadTranslationUrl,
+      "afterUpdateTranslation downloadTranslation",
+      this.downloadTranslation,
     );
     this.syncTranslationPlaybackVolume();
     if (this.data?.sendNotifyOnComplete && this.hadAsyncWait && isSuccess) {
@@ -1595,7 +1620,7 @@ function logBootstrap(
     Object.assign(payload, details);
   }
 
-  console.log(`[VOT][bootstrap][${ctx.frame}] ${message}`, payload);
+  debug.log(`[VOT][bootstrap][${ctx.frame}] ${message}`, payload);
 }
 
 function getServicesCached(): ServiceConf[] {

--- a/src/ui/manager.ts
+++ b/src/ui/manager.ts
@@ -1,4 +1,4 @@
-import type { VideoHandler } from "..";
+import type { VideoData, VideoHandler } from "..";
 import {
   actualCompatVersion,
   maxAudioVolume,
@@ -504,19 +504,24 @@ export class UIManager {
   private async handleDownloadTranslationClick() {
     const overlayView = this.votOverlayView;
     const videoHandler = this.videoHandler;
-    if (
-      !overlayView?.isInitialized() ||
-      !videoHandler?.downloadTranslationUrl ||
-      !videoHandler.videoData
-    ) {
+    const download = videoHandler?.downloadTranslation;
+    if (!overlayView?.isInitialized() || !download || !videoHandler.videoData) {
+      return;
+    }
+
+    const downloadVideoData = await this.getDownloadVideoData(
+      videoHandler,
+      download.videoId,
+    );
+    if (!downloadVideoData) {
       return;
     }
 
     const downloadButton = overlayView.downloadTranslationButton;
-    const downloadUrl = videoHandler.downloadTranslationUrl;
+    const downloadUrl = download.url;
     const filename = this.data.downloadWithName
-      ? clearFileName(videoHandler.videoData.downloadTitle)
-      : `translation_${videoHandler.videoData.videoId}`;
+      ? clearFileName(downloadVideoData.downloadTitle)
+      : `translation_${downloadVideoData.videoId}`;
     const isMobile = this.isLikelyMobileDownloadContext();
     const saveOptions: DownloadBlobOptions = { preferShare: isMobile };
 
@@ -541,6 +546,39 @@ export class UIManager {
       }
     } finally {
       setProgress(0);
+    }
+  }
+
+  private async getDownloadVideoData(
+    videoHandler: VideoHandler,
+    downloadVideoId: string,
+  ): Promise<VideoData | null> {
+    if (videoHandler.videoData?.videoId !== downloadVideoId) {
+      this.clearDownloadTranslation(videoHandler);
+      return null;
+    }
+
+    let videoData: VideoData;
+    try {
+      videoData = await videoHandler.getVideoData();
+    } catch (err) {
+      debug.log("[VOT] Failed to refresh video data before download", err);
+      return null;
+    }
+
+    if (videoData.videoId !== downloadVideoId) {
+      this.clearDownloadTranslation(videoHandler);
+      return null;
+    }
+
+    videoHandler.videoData = videoData;
+    return videoData;
+  }
+
+  private clearDownloadTranslation(videoHandler: VideoHandler): void {
+    videoHandler.downloadTranslation = null;
+    if (this.votOverlayView?.downloadTranslationButton) {
+      this.votOverlayView.downloadTranslationButton.hidden = true;
     }
   }
 

--- a/src/ui/views/settings.ts
+++ b/src/ui/views/settings.ts
@@ -47,7 +47,7 @@ import { availableLangs } from "@vot.js/shared/consts";
 import { html } from "lit-html";
 import { countryCode, type VideoHandler } from "../..";
 import {
-  authServerUrl,
+  authLoginUrl,
   defaultAutoHideDelay,
   defaultAutoVolume,
   defaultDetectService,
@@ -211,6 +211,14 @@ export class SettingsView {
     }
 
     void this.refreshAccountFromStorage();
+  };
+  private readonly refreshAccountOnFocus = () => {
+    void this.refreshAccountFromStorage();
+  };
+  private readonly refreshAccountOnVisibilityChange = () => {
+    if (document.visibilityState === "visible") {
+      void this.refreshAccountFromStorage();
+    }
   };
   dialog?: Dialog;
   accountButton?: AccountButton;
@@ -1144,6 +1152,11 @@ export class SettingsView {
       throw new Error("[VOT] SettingsView isn't initialized");
     }
     globalThis.addEventListener("message", this.onAuthRefreshMessage);
+    globalThis.addEventListener("focus", this.refreshAccountOnFocus);
+    document.addEventListener(
+      "visibilitychange",
+      this.refreshAccountOnVisibilityChange,
+    );
     this.accountButton.addEventListener("click", async () => {
       if (votStorage.isSupportOnlyLS) return;
       if (this.accountButton.loggedIn) {
@@ -1151,7 +1164,7 @@ export class SettingsView {
         this.data.account = {};
         return this.updateAccountInfo();
       }
-      globalThis.open(authServerUrl, "_blank")?.focus();
+      globalThis.open(authLoginUrl, "_blank")?.focus();
     });
     this.accountButton.addEventListener("click:secret", async () => {
       const dialog = new Dialog({
@@ -1626,6 +1639,11 @@ export class SettingsView {
     this.accountStorageListenerCleanup?.();
     this.accountStorageListenerCleanup = undefined;
     globalThis.removeEventListener("message", this.onAuthRefreshMessage);
+    globalThis.removeEventListener("focus", this.refreshAccountOnFocus);
+    document.removeEventListener(
+      "visibilitychange",
+      this.refreshAccountOnVisibilityChange,
+    );
     this.flushStoragePersists();
     for (const event of Object.values(this.events)) event.clear();
   }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -2,7 +2,7 @@ type DebugMethod = (...text: unknown[]) => void;
 
 const noop: DebugMethod = () => {};
 
-const log: DebugMethod = !DEBUG_MODE
+const log: DebugMethod = DEBUG_MODE
   ? (...text: unknown[]) => {
       console.log(
         "%c[VOT DEBUG]",
@@ -12,7 +12,7 @@ const log: DebugMethod = !DEBUG_MODE
     }
   : noop;
 
-const warn: DebugMethod = !DEBUG_MODE
+const warn: DebugMethod = DEBUG_MODE
   ? (...text: unknown[]) => {
       console.warn(
         "%c[VOT DEBUG]",
@@ -22,7 +22,7 @@ const warn: DebugMethod = !DEBUG_MODE
     }
   : noop;
 
-const error: DebugMethod = !DEBUG_MODE
+const error: DebugMethod = DEBUG_MODE
   ? (...text: unknown[]) => {
       console.error(
         "%c[VOT DEBUG]",

--- a/src/utils/fullscreenHelper.ts
+++ b/src/utils/fullscreenHelper.ts
@@ -21,6 +21,10 @@ export class FullscreenHelper {
   private container: HTMLElement;
   private video?: HTMLVideoElement;
   private fullscreenChangeListeners: Set<() => void> = new Set();
+  private readonly handleFullscreenChange = () => {
+    this.notifyFullscreenChange();
+  };
+  private nativeFullscreenListenersActive = false;
 
   constructor({ container, video }: FullscreenHelperOptions) {
     this.container = container;
@@ -160,49 +164,59 @@ export class FullscreenHelper {
    * Sets up native fullscreen event listeners
    */
   private setupFullscreenListeners(): void {
-    const handleFullscreenChange = () => {
-      this.notifyFullscreenChange();
-    };
+    if (this.nativeFullscreenListenersActive) {
+      return;
+    }
 
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
+    document.addEventListener("fullscreenchange", this.handleFullscreenChange);
+    document.addEventListener(
+      "webkitfullscreenchange",
+      this.handleFullscreenChange,
+    );
 
     if (this.video) {
       this.video.addEventListener(
         "webkitbeginfullscreen",
-        handleFullscreenChange,
+        this.handleFullscreenChange,
       );
       this.video.addEventListener(
         "webkitendfullscreen",
-        handleFullscreenChange,
+        this.handleFullscreenChange,
       );
     }
+
+    this.nativeFullscreenListenersActive = true;
   }
 
   /**
    * Cleans up fullscreen event listeners
    */
   private cleanupFullscreenListeners(): void {
-    const handleFullscreenChange = () => {
-      this.notifyFullscreenChange();
-    };
+    if (!this.nativeFullscreenListenersActive) {
+      return;
+    }
 
-    document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    document.removeEventListener(
+      "fullscreenchange",
+      this.handleFullscreenChange,
+    );
     document.removeEventListener(
       "webkitfullscreenchange",
-      handleFullscreenChange,
+      this.handleFullscreenChange,
     );
 
     if (this.video) {
       this.video.removeEventListener(
         "webkitbeginfullscreen",
-        handleFullscreenChange,
+        this.handleFullscreenChange,
       );
       this.video.removeEventListener(
         "webkitendfullscreen",
-        handleFullscreenChange,
+        this.handleFullscreenChange,
       );
     }
+
+    this.nativeFullscreenListenersActive = false;
   }
 
   /**
@@ -232,7 +246,15 @@ export class FullscreenHelper {
    * Updates the video reference
    */
   updateVideo(video: HTMLVideoElement | undefined): void {
+    const shouldRebind =
+      this.nativeFullscreenListenersActive && this.video !== video;
+    if (shouldRebind) {
+      this.cleanupFullscreenListeners();
+    }
     this.video = video;
+    if (shouldRebind && this.fullscreenChangeListeners.size > 0) {
+      this.setupFullscreenListeners();
+    }
   }
 
   /**

--- a/src/videoHandler/modules/init.ts
+++ b/src/videoHandler/modules/init.ts
@@ -123,7 +123,7 @@ export async function init(this: VideoHandler) {
 
   this.uiManager.data = this.data;
   // Translation volume starts from the user's saved default volume.
-  console.log("[VOT] data from db:", this.data);
+  debug.log("[VOT] data from db:", this.data);
 
   // Enable translate proxy if extension isn't compatible with GM_xmlhttpRequest
   if (!this.data.translateProxyEnabled && isProxyOnlyExtension) {

--- a/src/videoHandler/modules/smartDuckingRuntime.ts
+++ b/src/videoHandler/modules/smartDuckingRuntime.ts
@@ -260,6 +260,19 @@ function writeSmartDuckingRuntime(
   handler.smartVolumeRmsMissingSinceAt = runtime.rmsMissingSinceAt;
 }
 
+function restoreAutoVolumeMute(handler: VideoHandler): void {
+  if (typeof handler.autoVolumeMutedOnStart !== "boolean") {
+    return;
+  }
+
+  try {
+    handler.setVideoMuted(handler.autoVolumeMutedOnStart);
+  } catch {
+    // ignore
+  }
+  handler.autoVolumeMutedOnStart = undefined;
+}
+
 export function stopSmartVolumeDucking(
   handler: VideoHandler,
   options: StopSmartVolumeDuckingOptions = {},
@@ -286,6 +299,7 @@ export function stopSmartVolumeDucking(
       // ignore
     }
   }
+  restoreAutoVolumeMute(handler);
 
   releaseSmartDuckingAnalyser(handler);
   writeSmartDuckingRuntime(handler, initSmartDuckingRuntime());
@@ -440,7 +454,9 @@ function smartDuckingTick(handler: VideoHandler): void {
       });
       return;
     case "apply":
-      handler.setVideoVolume(decision.volume01);
+      handler.setVideoVolume(decision.volume01, {
+        preserveYoutubeVolumeStorage: true,
+      });
       writeSmartDuckingRuntime(handler, decision.runtime);
       return;
     case "noop":
@@ -472,6 +488,31 @@ export function setupAudioSettings(this: VideoHandler) {
     return;
   }
 
+  if (targetVolume === 0) {
+    if (this.smartVolumeDuckingInterval !== undefined) {
+      clearTimeout(this.smartVolumeDuckingInterval);
+      this.smartVolumeDuckingInterval = undefined;
+    }
+
+    if (typeof this.smartVolumeDuckingBaseline !== "number") {
+      this.smartVolumeDuckingBaseline = this.getVideoVolume();
+    }
+    if (typeof this.autoVolumeMutedOnStart !== "boolean") {
+      this.autoVolumeMutedOnStart = Boolean(this.isMuted());
+    }
+
+    this.setVideoVolume(0, { preserveYoutubeVolumeStorage: true });
+    this.setVideoMuted(true, { preserveYoutubeVolumeStorage: true });
+    writeSmartDuckingRuntime(
+      this,
+      initSmartDuckingRuntime(this.smartVolumeDuckingBaseline),
+    );
+    this.smartVolumeIsDucked = true;
+    return;
+  }
+
+  restoreAutoVolumeMute(this);
+
   if (autoVolumeMode === "smart") {
     startSmartVolumeDucking(this);
     return;
@@ -488,7 +529,7 @@ export function setupAudioSettings(this: VideoHandler) {
 
   const baseline = this.smartVolumeDuckingBaseline ?? this.getVideoVolume();
   const nextVolume = Math.min(baseline, targetVolume);
-  this.setVideoVolume(nextVolume);
+  this.setVideoVolume(nextVolume, { preserveYoutubeVolumeStorage: true });
 
   writeSmartDuckingRuntime(
     this,

--- a/src/videoHandler/modules/subtitles.ts
+++ b/src/videoHandler/modules/subtitles.ts
@@ -190,7 +190,7 @@ export async function changeSubtitlesLang(
       ...subtitlesObj,
       url: proxiedSubtitlesUrl,
     };
-    console.log(`[VOT] Subs proxied via ${subtitlesObj.url}`);
+    debug.log(`[VOT] Subs proxied via ${subtitlesObj.url}`);
   }
 
   const fetchedSubtitles =

--- a/src/videoHandler/modules/translationPlayback.ts
+++ b/src/videoHandler/modules/translationPlayback.ts
@@ -301,7 +301,7 @@ async function requestApplyAndCacheTranslation(
     requestLang: options.cacheRequestLang,
     responseLang: options.cacheResponseLang,
     fallbackUrl: translateRes.url,
-    downloadTranslationUrl: self.downloadTranslationUrl,
+    downloadTranslationUrl: self.downloadTranslation?.url,
     usedLivelyVoice: translateRes.usedLivelyVoice,
   });
 

--- a/tests/fullscreen-helper.test.ts
+++ b/tests/fullscreen-helper.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { FullscreenHelper } from "../src/utils/fullscreenHelper.ts";
+
+function createListenerTarget() {
+  const listeners = new Map<string, Set<EventListener>>();
+
+  return {
+    addEventListener(type: string, listener: EventListener) {
+      const typeListeners = listeners.get(type) ?? new Set<EventListener>();
+      typeListeners.add(listener);
+      listeners.set(type, typeListeners);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    listenerCount() {
+      return [...listeners.values()].reduce(
+        (sum, typeListeners) => sum + typeListeners.size,
+        0,
+      );
+    },
+  };
+}
+
+describe("FullscreenHelper", () => {
+  test("removes the same native listeners that it added", () => {
+    const previousDocument = globalThis.document;
+    const documentTarget = createListenerTarget();
+    const videoTarget = createListenerTarget();
+
+    try {
+      (globalThis as unknown as { document: unknown }).document =
+        documentTarget;
+
+      const helper = new FullscreenHelper({
+        container: {} as HTMLElement,
+        video: videoTarget as unknown as HTMLVideoElement,
+      });
+      const listener = () => {};
+
+      helper.addFullscreenChangeListener(listener);
+      expect(documentTarget.listenerCount()).toBe(2);
+      expect(videoTarget.listenerCount()).toBe(2);
+
+      helper.removeFullscreenChangeListener(listener);
+      expect(documentTarget.listenerCount()).toBe(0);
+      expect(videoTarget.listenerCount()).toBe(0);
+    } finally {
+      (globalThis as unknown as { document: unknown }).document =
+        previousDocument;
+    }
+  });
+});

--- a/tests/smart-ducking.test.ts
+++ b/tests/smart-ducking.test.ts
@@ -212,6 +212,73 @@ describe("smart ducking engine", () => {
     expect(state.currentVolume).toBe(0.1);
   });
 
+  test("zero auto-volume mutes the original track and restores mute state", async () => {
+    (globalThis as unknown as { DEBUG_MODE: boolean }).DEBUG_MODE = false;
+    const { setupAudioSettings, stopSmartVolumeDucking } = await import(
+      "../src/videoHandler/modules/smartDuckingRuntime.ts"
+    );
+    const volumeWrites: Array<{
+      volume: number;
+      preserveStorage: boolean | undefined;
+    }> = [];
+    const muteWrites: Array<{
+      muted: boolean;
+      preserveStorage: boolean | undefined;
+    }> = [];
+    let currentVolume = 0.7;
+    let currentMuted = false;
+    const handler = {
+      data: {
+        autoVolume: 0,
+        enabledAutoVolume: true,
+        enabledSmartDucking: true,
+        syncVolume: false,
+      },
+      audioPlayer: { player: { volume: 1 } },
+      hasActiveSource: () => true,
+      getVideoVolume: () => currentVolume,
+      isMuted: () => currentMuted,
+      setVideoVolume: (
+        volume: number,
+        options?: { preserveYoutubeVolumeStorage?: boolean },
+      ) => {
+        currentVolume = volume;
+        volumeWrites.push({
+          volume,
+          preserveStorage: options?.preserveYoutubeVolumeStorage,
+        });
+      },
+      setVideoMuted: (
+        muted: boolean,
+        options?: { preserveYoutubeVolumeStorage?: boolean },
+      ) => {
+        currentMuted = muted;
+        muteWrites.push({
+          muted,
+          preserveStorage: options?.preserveYoutubeVolumeStorage,
+        });
+      },
+    } as any;
+
+    setupAudioSettings.call(handler);
+
+    expect(volumeWrites).toEqual([{ volume: 0, preserveStorage: true }]);
+    expect(muteWrites).toEqual([{ muted: true, preserveStorage: true }]);
+    expect(handler.smartVolumeDuckingBaseline).toBe(0.7);
+    expect(handler.autoVolumeMutedOnStart).toBe(false);
+
+    stopSmartVolumeDucking(handler);
+
+    expect(volumeWrites.at(-1)).toEqual({
+      volume: 0.7,
+      preserveStorage: undefined,
+    });
+    expect(muteWrites.at(-1)).toEqual({
+      muted: false,
+      preserveStorage: undefined,
+    });
+  });
+
   test("stop decision returns restore volume from baseline or volumeOnStart", () => {
     const withBaseline = computeSmartDuckingStep(
       {

--- a/tests/video-manager-volume.test.ts
+++ b/tests/video-manager-volume.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+const YOUTUBE_PLAYER_VOLUME_STORAGE_KEY = "yt-player-volume";
+
+function createStorage(initialValue: string | null) {
+  let value = initialValue;
+
+  return {
+    getItem(key: string) {
+      return key === YOUTUBE_PLAYER_VOLUME_STORAGE_KEY ? value : null;
+    },
+    setItem(key: string, nextValue: string) {
+      if (key === YOUTUBE_PLAYER_VOLUME_STORAGE_KEY) {
+        value = nextValue;
+      }
+    },
+    removeItem(key: string) {
+      if (key === YOUTUBE_PLAYER_VOLUME_STORAGE_KEY) {
+        value = null;
+      }
+    },
+    read() {
+      return value;
+    },
+  };
+}
+
+describe("VOTVideoManager YouTube volume writes", () => {
+  test("preserves YouTube storage only for auto-volume writes", async () => {
+    (globalThis as unknown as { DEBUG_MODE: boolean }).DEBUG_MODE = false;
+    const { VOTVideoManager } = await import("../src/core/videoManager.ts");
+    const { default: YoutubeHelper } = await import(
+      "@vot.js/ext/helpers/youtube"
+    );
+    const originalSetVolume = YoutubeHelper.setVolume;
+    const previousLocalStorage = globalThis.localStorage;
+    const storage = createStorage("user-volume");
+
+    try {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: storage,
+      });
+      YoutubeHelper.setVolume = ((volume: number) => {
+        globalThis.localStorage.setItem(
+          YOUTUBE_PLAYER_VOLUME_STORAGE_KEY,
+          `written:${volume}`,
+        );
+        return true;
+      }) as typeof YoutubeHelper.setVolume;
+
+      const manager = new VOTVideoManager({
+        site: { host: "youtube" },
+        video: { volume: 0.75, muted: false },
+      } as any);
+
+      manager.setVideoVolume(0.2);
+      expect(storage.read()).toBe("written:0.2");
+
+      storage.setItem(YOUTUBE_PLAYER_VOLUME_STORAGE_KEY, "user-volume");
+      manager.setVideoVolume(0.1, { preserveYoutubeVolumeStorage: true });
+      expect(storage.read()).toBe("user-volume");
+    } finally {
+      YoutubeHelper.setVolume = originalSetVolume;
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: previousLocalStorage,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Tie translated-audio downloads to the source video id and refresh current metadata before naming the file.
- Mute the original track when auto-volume is 0%, then restore the previous mute state when translation stops.
- Preserve YouTube's saved player volume only for VOT auto-volume writes, so manual volume changes still persist.
- Open the current auth handler directly and clean up debug/fullscreen listener regressions.

## Issues
- Fixes https://github.com/ilyhalight/voice-over-translation/issues/1670
- Fixes https://github.com/ilyhalight/voice-over-translation/issues/1602
- Fixes https://github.com/ilyhalight/voice-over-translation/issues/1656
- Related: https://github.com/ilyhalight/voice-over-translation/issues/1567, https://github.com/ilyhalight/voice-over-translation/issues/1257

## Proof
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm exec --yes bun -- test` — 20 pass / 0 fail
- `npm exec --yes @biomejs/biome -- check src tests`
- `./node_modules/.bin/vite build --config vite.test-ui.config.ts`
- tmp `./node_modules/.bin/vite build --config vite.extension.config.ts` — Chrome/Firefox verification passed
- production Chrome/Firefox packages contain no `VOT DEBUG` strings
- `git diff --check`
