### PR TITLE
Remove redundant account refresh listeners

### DIFF
--- a/src/ui/views/settings.ts
+++ b/src/ui/views/settings.ts
@@ -212,14 +212,6 @@ export class SettingsView {
 
     void this.refreshAccountFromStorage();
   };
-  private readonly refreshAccountOnFocus = () => {
-    void this.refreshAccountFromStorage();
-  };
-  private readonly refreshAccountOnVisibilityChange = () => {
-    if (document.visibilityState === "visible") {
-      void this.refreshAccountFromStorage();
-    }
-  };
   dialog?: Dialog;
   accountButton?: AccountButton;
   accountButtonRefreshTooltip?: Tooltip;
@@ -1152,11 +1144,6 @@ export class SettingsView {
       throw new Error("[VOT] SettingsView isn't initialized");
     }
     globalThis.addEventListener("message", this.onAuthRefreshMessage);
-    globalThis.addEventListener("focus", this.refreshAccountOnFocus);
-    document.addEventListener(
-      "visibilitychange",
-      this.refreshAccountOnVisibilityChange,
-    );
     this.accountButton.addEventListener("click", async () => {
       if (votStorage.isSupportOnlyLS) return;
       if (this.accountButton.loggedIn) {
@@ -1639,11 +1626,6 @@ export class SettingsView {
     this.accountStorageListenerCleanup?.();
     this.accountStorageListenerCleanup = undefined;
     globalThis.removeEventListener("message", this.onAuthRefreshMessage);
-    globalThis.removeEventListener("focus", this.refreshAccountOnFocus);
-    document.removeEventListener(
-      "visibilitychange",
-      this.refreshAccountOnVisibilityChange,
-    );
     this.flushStoragePersists();
     for (const event of Object.values(this.events)) event.clear();
   }


### PR DESCRIPTION
## Summary
- Remove redundant account refresh on window focus and tab visibility changes.
- Keep account refresh on the existing auth `message` handler only.

## Context
- Follow-up to https://github.com/ilyhalight/voice-over-translation/pull/1671#issuecomment-4317336126

## Proof
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm exec --yes bun -- test` — 20 pass / 0 fail
- `npm exec --yes @biomejs/biome -- check src tests`
- tmp `./node_modules/.bin/vite build --config vite.extension.config.ts`
- `git diff --check`