### PR TITLE
fix: correct inverted return value in shouldRetryAudioProbe

### DIFF
--- a/src/videoHandler/modules/translationPlayback.ts
+++ b/src/videoHandler/modules/translationPlayback.ts
@@ -176,7 +176,7 @@ async function shouldRetryAudioProbe(
   signal: AbortSignal,
 ): Promise<boolean> {
   if (attempt >= AUDIO_PROBE_MAX_ATTEMPTS) {
-    return true;
+    return false;
   }
   if (isProbeCancelled(handler, actionContext, signal)) {
     return false;


### PR DESCRIPTION
## Summary

`shouldRetryAudioProbe` returns an inverted value on the last-attempt branch.

## Details

```typescript
async function shouldRetryAudioProbe(
  attempt: number,
  ...
): Promise<boolean> {
  if (attempt >= AUDIO_PROBE_MAX_ATTEMPTS) {
    return true;  // ← semantically wrong: says "yes, retry" when no retries remain
  }
  ...
}
```

With `AUDIO_PROBE_MAX_ATTEMPTS = 2`, when `attempt = 2` (the final attempt), this function returns `true` — "yes, retry" — even though the retry budget is exhausted.

The caller uses the return value as:
```typescript
if (!(await shouldRetryAudioProbe(attempt, ...))) {
  return false;
}
```

In practice, the bounded `for`-loop (`attempt <= AUDIO_PROBE_MAX_ATTEMPTS`) naturally terminates after the last iteration regardless of the return value, so **observable behavior is unchanged** by this fix. The 150 ms back-off delay between attempts is also correctly applied (it runs inside `shouldRetryAudioProbe(1, ...)`, before the second attempt).

However, the inverted return value is still worth fixing because:

1. **Semantics are wrong and misleading**: the function's contract is "should we retry?", and answering `true` when retries are exhausted contradicts the intent. Anyone reading this code gets the wrong mental model.

2. **Latent risk on refactoring**: if the `for`-loop is ever refactored to a `while`-based pattern (e.g. `while (await shouldRetryAudioProbe(...))`), the current `return true` would cause an infinite loop.

## Fix

One-line change: `return true` → `return false`.

```diff
 async function shouldRetryAudioProbe(...): Promise<boolean> {
   if (attempt >= AUDIO_PROBE_MAX_ATTEMPTS) {
-    return true;
+    return false;
   }
   ...
 }
```

## Proof
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm exec --yes bun -- test` — 23 pass / 0 fail
- `npm exec --yes @biomejs/biome -- check src tests`
- `git diff --check origin/master`