### PR TITLE
perf: use indexed loops for TypedArray RMS & early-break in MutationObserver

### DIFF
--- a/src/videoHandler/modules/events.ts
+++ b/src/videoHandler/modules/events.ts
@@ -225,6 +225,7 @@ function bindYouTubeVolumeSync(ctx: ExtraEventsContext): void {
         continue;
       }
       hasVolumeMutation = true;
+      break;
     }
     if (!hasVolumeMutation) return;
     self.syncVideoVolumeSlider();

--- a/src/videoHandler/modules/smartDuckingRuntime.ts
+++ b/src/videoHandler/modules/smartDuckingRuntime.ts
@@ -381,8 +381,8 @@ function getTranslatedAudioRms(
       analyser.getFloatTimeDomainData(floatData);
 
       let sum = 0;
-      for (const value of floatData) {
-        sum += value * value;
+      for (let i = 0; i < floatData.length; i++) {
+        sum += floatData[i] * floatData[i];
       }
       return clamp(Math.sqrt(sum / floatData.length), 0, 1);
     }
@@ -396,8 +396,8 @@ function getTranslatedAudioRms(
     analyser.getByteTimeDomainData(data);
 
     let sum = 0;
-    for (const rawValue of data) {
-      const normalizedValue = (rawValue - 128) / 128;
+    for (let i = 0; i < data.length; i++) {
+      const normalizedValue = (data[i] - 128) / 128;
       sum += normalizedValue * normalizedValue;
     }
     return clamp(Math.sqrt(sum / data.length), 0, 1);


### PR DESCRIPTION
## Summary

Two targeted micro-optimizations for the smart ducking hot path and YouTube volume synchronization.

### 1. Use indexed loops for TypedArray RMS computation (`smartDuckingRuntime.ts`)

`getTranslatedAudioRms()` computes RMS over a `Float32Array` (primary path) or `Uint8Array` (fallback). The current `for...of` loop goes through `Symbol.iterator`, which allocates an iterator object and calls `.next()` on each element.

JIT compilers can eliminate this overhead in some cases, but it is not guaranteed across all browsers and optimization tiers. An indexed `for`-loop avoids the allocation unconditionally and is the conventional approach for TypedArray processing in performance-sensitive paths.

This loop runs **every 50 ms** (`SMART_DUCKING_TICK_MS`) with `fftSize = 512` elements — it is the only continuously scheduled hot path in the extension.

**Before:**
```typescript
for (const value of floatData) {
  sum += value * value;
}
```

**After:**
```typescript
for (let i = 0; i < floatData.length; i++) {
  sum += floatData[i] * floatData[i];
}
```

Same fix applied to the `Uint8Array` fallback path.

### 2. Early break in MutationObserver volume sync loop (`events.ts`)

`bindYouTubeVolumeSync` iterates all mutations even after finding the first `aria-valuenow` attribute change. Since the only action taken inside the loop body is setting a boolean flag (`hasVolumeMutation = true`), the loop can safely exit after the first match.

### Impact

- **RMS loop**: eliminates iterator allocation on every tick; the benefit depends on engine and optimization tier, but the change is zero-cost and follows established practice for TypedArray hot paths
- **MutationObserver**: minor — YouTube typically batches 1–3 mutations, but stopping early is the correct pattern once the goal is achieved
- **No behavioral changes** — both fixes produce identical output

## Proof
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm exec --yes bun -- test` — 23 pass / 0 fail
- `npm exec --yes @biomejs/biome -- check src tests`
- `git diff --check origin/master`