### PR TITLE
fix: Sync translation audio playback rate with third-party speed controllers  

### DIFF
--- a/src/videoHandler/modules/events.ts
+++ b/src/videoHandler/modules/events.ts
@@ -470,6 +470,28 @@ export function bindPlaybackRefreshOnResume(ctx: ExtraEventsContext): void {
   add(self.video, "loadstart", resetPauseState);
   add(self.video, "emptied", resetPauseState);
 }
+
+// Fallback playback-rate sync. chaimu already syncs on the native `ratechange`
+// event, but some speed controllers (e.g. Video Speed Controller) set
+// `playbackRate` directly and suppress that event, so we also reconcile on
+// `timeupdate` (not suppressed, fires during playback).
+export function bindPlaybackRateFallbackSync(ctx: ExtraEventsContext): void {
+  const { self, add } = ctx;
+
+  const syncRate = () => {
+    if (!self.hasActiveSource() || !self.audioPlayer?.player) return;
+    if (
+      Math.abs(self.audioPlayer.player.playbackRate - self.video.playbackRate) <
+      0.01
+    )
+      return;
+
+    self.audioPlayer.player.lipSync("ratechange");
+  };
+
+  add(self.video, "timeupdate", syncRate);
+}
+
 function bindVideoLifecycleEvents(ctx: ExtraEventsContext): void {
   const { self, overlayView, add } = ctx;
   const safeSetCanPlay = async () => {
@@ -551,6 +573,7 @@ export function initExtraEvents(this: VideoHandler) {
     addMany,
   };
   bindPlaybackRefreshOnResume(ctx);
+  bindPlaybackRateFallbackSync(ctx);
   bindOverlayLayoutEvents(ctx);
   bindYouTubeVolumeSync(ctx);
   bindAudioTrackLanguageSync(ctx);


### PR DESCRIPTION

## Description

The translation audio did not follow the video playback rate in real time. When the speed was changed via a third-party extension (e.g. [Video Speed Controller](https://github.com/igrigorik/videospeed)), the translation kept playing at the old rate and only re-synced after a pause/resume cycle.

## Problem

chaimu already syncs the audio rate on the native `ratechange` event, which covers in-page changes (the YouTube speed menu, etc.). But speed controllers set `video.playbackRate` directly and **suppress the `ratechange` event** so the host page can't reset their speed. As a result, neither chaimu's listener nor anything else fires, and the audio/video rates drift apart until the next play/pause re-runs lip sync.

## Solution

Added a fallback reconciliation on `timeupdate` (not suppressed by speed controllers, fires during playback) in `src/videoHandler/modules/events.ts`:

```ts
export function bindPlaybackRateFallbackSync(ctx: ExtraEventsContext): void {
  const { self, add } = ctx;

  const syncRate = () => {
    if (!self.hasActiveSource() || !self.audioPlayer?.player) return;
    if (
      Math.abs(self.audioPlayer.player.playbackRate - self.video.playbackRate) <
      0.01
    )
      return;

    self.audioPlayer.player.lipSync("ratechange");
  };

  add(self.video, "timeupdate", syncRate);
}
```

- `ratechange` is intentionally **not** subscribed here — chaimu already handles it; this is purely a fallback for controllers that hide the event.
- A diff guard (`< 0.01`) means steady-state playback does no extra work; `lipSync` runs only when the rates actually differ.
- The listener is registered through the existing scoped `add` (tied to `abortController.signal`), so it is cleaned up on `release()` automatically.

## Testing

- YouTube speed menu — still syncs instantly (unchanged, via chaimu).
- Video Speed Controller — translation audio now follows the new speed within one `timeupdate` tick (≤ ~250 ms), no pause/resume needed.

## Checklist

- [x] Written in TypeScript
- [x] No new localization phrases (localization types/hashes untouched)
- [x] No `dist/` changes included in the source change (rebuild via `bun run build`)
- [x] hls.js / vot.js versions untouched
