### PR TITLE
feat: add option to pause video during translation preparation

### DIFF
--- a/dist/vot.user.js
+++ b/dist/vot.user.js
@@ -2621,8 +2621,11 @@ var vot = (function(exports) {
 	var protoInt64 = /*@__PURE__*/ makeInt64Support();
 	function makeInt64Support() {
 		const dv = /* @__PURE__ */ new DataView(/* @__PURE__ */ new ArrayBuffer(8));
-		if (typeof BigInt === "function" && typeof dv.getBigInt64 === "function" && typeof dv.getBigUint64 === "function" && typeof dv.setBigInt64 === "function" && typeof dv.setBigUint64 === "function" && (typeof process != "object" || typeof process.env != "object" || process.env.BUF_BIGINT_DISABLE !== "1")) {
-			const MIN = BigInt("-9223372036854775808"), MAX = BigInt("9223372036854775807"), UMIN = BigInt("0"), UMAX = BigInt("18446744073709551615");
+		if (typeof BigInt === "function" && typeof dv.getBigInt64 === "function" && typeof dv.getBigUint64 === "function" && typeof dv.setBigInt64 === "function" && typeof dv.setBigUint64 === "function" && (!!globalThis.Deno || !!globalThis.Bun || typeof process != "object" || typeof process.env != "object" || process.env.BUF_BIGINT_DISABLE !== "1")) {
+			const MIN = BigInt("-9223372036854775808");
+			const MAX = BigInt("9223372036854775807");
+			const UMIN = BigInt("0");
+			const UMAX = BigInt("18446744073709551615");
 			return {
 				zero: BigInt(0),
 				supported: true,
@@ -2706,17 +2709,22 @@ var vot = (function(exports) {
 		if (globalThis[symbol] == void 0) {
 			const te = new globalThis.TextEncoder();
 			const td = new globalThis.TextDecoder();
+			let tdStrict;
 			globalThis[symbol] = {
 				encodeUtf8(text) {
 					return te.encode(text);
 				},
-				decodeUtf8(bytes) {
+				decodeUtf8(bytes, strict) {
+					if (strict) {
+						if (tdStrict === void 0) tdStrict = new globalThis.TextDecoder("utf-8", { fatal: true });
+						return tdStrict.decode(bytes);
+					}
 					return td.decode(bytes);
 				},
 				checkUtf8(text) {
 					try {
 						return true;
-					} catch (e) {
+					} catch (_) {
 						return false;
 					}
 				}
@@ -2867,7 +2875,7 @@ var vot = (function(exports) {
 			return this;
 		}
 		/**
-		* Write a `bool` value, a variant.
+		* Write a `bool` value, a varint.
 		*/
 		bool(value) {
 			this.buf.push(value ? 1 : 0);
@@ -2933,7 +2941,7 @@ var vot = (function(exports) {
 			return this;
 		}
 		/**
-		* Write a `fixed64` value, a signed, fixed-length 64-bit integer.
+		* Write a `sfixed64` value, a signed, fixed-length 64-bit integer.
 		*/
 		sfixed64(value) {
 			let chunk = /* @__PURE__ */ new Uint8Array(8), view = new DataView(chunk.buffer), tc = protoInt64.enc(value);
@@ -2962,7 +2970,7 @@ var vot = (function(exports) {
 		* Write a `sint64` value, a signed, zig-zag-encoded 64-bit varint.
 		*/
 		sint64(value) {
-			let tc = protoInt64.enc(value), sign = tc.hi >> 31;
+			const tc = protoInt64.enc(value), sign = tc.hi >> 31;
 			varint64write(tc.lo << 1 ^ sign, (tc.hi << 1 | tc.lo >>> 31) ^ sign, this.buf);
 			return this;
 		}
@@ -2970,7 +2978,7 @@ var vot = (function(exports) {
 		* Write a `uint64` value, an unsigned 64-bit varint.
 		*/
 		uint64(value) {
-			let tc = protoInt64.uEnc(value);
+			const tc = protoInt64.uEnc(value);
 			varint64write(tc.lo, tc.hi, this.buf);
 			return this;
 		}
@@ -2989,20 +2997,28 @@ var vot = (function(exports) {
 			this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
 		}
 		/**
-		* Reads a tag - field number and wire type.
+		* Reads a tag - field number and wire type. Tags are uint32 varints; values
+		* that do not fit in uint32 are rejected.
 		*/
 		tag() {
-			let tag = this.uint32(), fieldNo = tag >>> 3, wireType = tag & 7;
-			if (fieldNo <= 0 || wireType < 0 || wireType > 5) throw new Error("illegal tag: field no " + fieldNo + " wire type " + wireType);
+			const start = this.pos;
+			const tag = this.uint32();
+			const bytesRead = this.pos - start;
+			if (bytesRead > 5 || bytesRead == 5 && this.buf[this.pos - 1] > 15) throw new Error("illegal tag: varint overflows uint32");
+			const fieldNo = tag >>> 3;
+			const wireType = tag & 7;
+			if (fieldNo <= 0 || wireType > 5) throw new Error("illegal tag: field no " + fieldNo + " wire type " + wireType);
 			return [fieldNo, wireType];
 		}
 		/**
 		* Skip one element and return the skipped data.
 		*
 		* When skipping StartGroup, provide the tags field number to check for
-		* matching field number in the EndGroup tag.
+		* matching field number in the EndGroup tag. Recursion into nested groups
+		* is guarded by the `recursionLimit` argument: When the limit is reached,
+		* this method throws.
 		*/
-		skip(wireType, fieldNo) {
+		skip(wireType, fieldNo, recursionLimit = 100) {
 			let start = this.pos;
 			switch (wireType) {
 				case WireType.Varint:
@@ -3017,13 +3033,14 @@ var vot = (function(exports) {
 					this.pos += len;
 					break;
 				case WireType.StartGroup:
+					if (recursionLimit <= 0) throw new Error("maximum recursion depth reached");
 					for (;;) {
 						const [fn, wt] = this.tag();
 						if (wt === WireType.EndGroup) {
 							if (fieldNo !== void 0 && fn !== fieldNo) throw new Error("invalid end group tag");
 							break;
 						}
-						this.skip(wt, fn);
+						this.skip(wt, fn, recursionLimit - 1);
 					}
 					break;
 				default: throw new Error("cant skip wire type " + wireType);
@@ -3125,10 +3142,11 @@ var vot = (function(exports) {
 			return this.buf.subarray(start, start + len);
 		}
 		/**
-		* Read a `string` field, length-delimited data converted to UTF-8 text.
+		* Read a `string` field, length-delimited data converted to UTF-8 text. If
+		* `strict` is true, throw on invalid UTF-8 instead of substituting U+FFFD.
 		*/
-		string() {
-			return this.decodeUtf8(this.bytes());
+		string(strict) {
+			return this.decodeUtf8(this.bytes(), strict);
 		}
 	};
 	/**
@@ -3154,7 +3172,7 @@ var vot = (function(exports) {
 		if (typeof arg == "string") {
 			const o = arg;
 			arg = Number(arg);
-			if (isNaN(arg) && o !== "NaN") throw new Error("invalid float32: " + o);
+			if (Number.isNaN(arg) && o !== "NaN") throw new Error("invalid float32: " + o);
 		} else if (typeof arg != "number") throw new Error("invalid float32: " + typeof arg);
 		if (Number.isFinite(arg) && (arg > 34028234663852886e22 || arg < -34028234663852886e22)) throw new Error("invalid float32: " + arg);
 	}
@@ -6774,6 +6792,7 @@ var vot = (function(exports) {
 	var subtitleResponseLanguageModes = ["auto", "original"];
 	var storageKeys = [
 		"autoTranslate",
+		"autoPauseOnTranslate",
 		"autoSubtitles",
 		"dontTranslateLanguages",
 		"enabledDontTranslateLanguages",
@@ -9836,6 +9855,7 @@ var vot = (function(exports) {
 		VOTFailedDownloadAudio: "Failed to download audio",
 		audioFormatNotSupported: "The audio format is not supported",
 		VOTAutoTranslate: "Translate on open",
+		VOTAutoPauseOnTranslate: "Pause video until translation is ready",
 		VOTAutoSubtitles: "Subtitles on open",
 		VOTDontTranslateYourLang: "Don't translate from my language",
 		VOTVolume: "Video volume:",
@@ -11931,20 +11951,20 @@ var vot = (function(exports) {
 		}
 	};
 	//#endregion
-	//#region ../../chaimu/dist/config.js
+	//#region node_modules/chaimu/dist/config.js
 	var config_default = {
 		version: "1.1.0",
 		debug: false,
 		fetchFn: fetch.bind(window)
 	};
 	//#endregion
-	//#region ../../chaimu/dist/debug.js
+	//#region node_modules/chaimu/dist/debug.js
 	var debug_default = { log: (...text) => {
 		if (!config_default.debug) return;
 		return console.log(`%c✦ chaimu.js v${config_default.version} ✦`, "background: #000; color: #fff; padding: 0 8px", ...text);
 	} };
 	//#endregion
-	//#region ../../chaimu/dist/player.js
+	//#region node_modules/chaimu/dist/player.js
 	var videoLipSyncEvents = [
 		"playing",
 		"ratechange",
@@ -12491,7 +12511,7 @@ var vot = (function(exports) {
 		}
 	};
 	//#endregion
-	//#region ../../chaimu/dist/client.js
+	//#region node_modules/chaimu/dist/client.js
 	var Chaimu = class {
 		_debug = false;
 		audioContext;
@@ -22584,6 +22604,7 @@ var vot = (function(exports) {
 		"click:resetSettings",
 		"update:account",
 		"change:autoTranslate",
+		"change:autoPauseOnTranslate",
 		"change:autoSubtitles",
 		"change:showVideoVolume",
 		"change:audioBooster",
@@ -22673,6 +22694,7 @@ var vot = (function(exports) {
 		accountButtonTokenTooltip;
 		accountStorageListenerCleanup;
 		autoTranslateCheckbox;
+		autoPauseOnTranslateCheckbox;
 		autoSubtitlesCheckbox;
 		dontTranslateLanguagesCheckbox;
 		dontTranslateLanguagesSelect;
@@ -22946,6 +22968,10 @@ var vot = (function(exports) {
 				labelHtml: localizationProvider.get("VOTAutoTranslate"),
 				checked: this.data.autoTranslate
 			});
+			this.autoPauseOnTranslateCheckbox = new Checkbox({
+				labelHtml: localizationProvider.get("VOTAutoPauseOnTranslate"),
+				checked: this.data.autoPauseOnTranslate
+			});
 			this.autoSubtitlesCheckbox = new Checkbox({
 				labelHtml: localizationProvider.get("VOTAutoSubtitles"),
 				checked: this.data.autoSubtitles
@@ -23036,7 +23062,7 @@ var vot = (function(exports) {
 				parentElement: this.globalPortal
 			});
 			accountSection.content.append(this.accountButton.container);
-			translationSection.content.append(this.autoTranslateCheckbox.container, this.autoSubtitlesCheckbox.container, this.dontTranslateLanguagesSelect.container, this.autoSetVolumeSlider.container, this.smartDuckingCheckbox.container, this.showVideoVolumeSliderCheckbox.container, this.audioBoosterCheckbox.container, this.syncVolumeCheckbox.container, this.downloadWithNameCheckbox.container, this.sendNotifyOnCompleteCheckbox.container, this.useAudioDownloadCheckbox.container);
+			translationSection.content.append(this.autoTranslateCheckbox.container, this.autoPauseOnTranslateCheckbox.container, this.autoSubtitlesCheckbox.container, this.dontTranslateLanguagesSelect.container, this.autoSetVolumeSlider.container, this.smartDuckingCheckbox.container, this.showVideoVolumeSliderCheckbox.container, this.audioBoosterCheckbox.container, this.syncVolumeCheckbox.container, this.downloadWithNameCheckbox.container, this.sendNotifyOnCompleteCheckbox.container, this.useAudioDownloadCheckbox.container);
 			this.subtitlesDownloadFormatSelectLabel = new Label({ labelText: localizationProvider.get("VOTSubtitlesDownloadFormat") });
 			this.subtitlesDownloadFormatSelect = new Select({
 				selectTitle: this.data.subtitlesDownloadFormat ?? localizationProvider.get("VOTSubtitlesDownloadFormat"),
@@ -23347,6 +23373,17 @@ var vot = (function(exports) {
 				readPersistedValue: () => this.data.autoTranslate,
 				logLabel: "autoTranslate",
 				dispatch: (checked) => this.events["change:autoTranslate"].dispatch(checked)
+			});
+			this.bindPersistedSetting({
+				control: this.autoPauseOnTranslateCheckbox,
+				event: "change",
+				apply: (checked) => {
+					this.data.autoPauseOnTranslate = checked;
+				},
+				storageKey: "autoPauseOnTranslate",
+				readPersistedValue: () => this.data.autoPauseOnTranslate,
+				logLabel: "autoPauseOnTranslate",
+				dispatch: (checked) => this.events["change:autoPauseOnTranslate"].dispatch(checked)
 			});
 			this.bindPersistedSetting({
 				control: this.autoSubtitlesCheckbox,
@@ -25390,6 +25427,14 @@ var vot = (function(exports) {
 				debug.log("[translateFunc] Cached translation was received");
 				return;
 			}
+			if (this.data?.autoPauseOnTranslate && !this.video.paused && !this.video.ended) {
+				debug.log("[translateFunc] Pausing video until translation is ready");
+				this.pausedByTranslation = true;
+				this.video.addEventListener("play", () => {
+					this.pausedByTranslation = false;
+				}, { once: true });
+				this.video.pause();
+			}
 			const translateRes = await requestApplyAndCacheTranslation(this, {
 				videoData,
 				requestLang: reqLang,
@@ -25433,6 +25478,15 @@ var vot = (function(exports) {
 			throw err;
 		} finally {
 			if (this.activeTranslation?.promise === translationPromise) this.activeTranslation = null;
+			if (!this.activeTranslation && this.pausedByTranslation) {
+				this.pausedByTranslation = false;
+				if (this.hasActiveSource()) {
+					debug.log("[translateFunc] Resuming video after translation is ready");
+					this.video.play().catch((playErr) => {
+						debug.log("[translateFunc] Failed to resume video", playErr);
+					});
+				}
+			}
 			const overlayBtn = this.uiManager.votOverlayView?.votButton;
 			if (!this.activeTranslation && overlayBtn?.loading && !this.hasActiveSource()) {
 				debug.log("[translateFunc] clearing stale loading state");
@@ -25852,6 +25906,7 @@ var vot = (function(exports) {
 		const audioContextSupported = this.isAudioContextSupported;
 		this.data = await votStorage.getValues({
 			autoTranslate: false,
+			autoPauseOnTranslate: false,
 			autoSubtitles: false,
 			dontTranslateLanguages: [calculatedResLang],
 			enabledDontTranslateLanguages: true,
@@ -26982,6 +27037,12 @@ var vot = (function(exports) {
 		smartVolumeIsDucked = false;
 		longWaitingResCount = 0;
 		hadAsyncWait = false;
+		/**
+		* Set to `true` when the video was programmatically paused while waiting for
+		* translation audio to be prepared (autoPauseOnTranslate feature).
+		* Reset when translation finishes or when the user manually starts playback.
+		*/
+		pausedByTranslation = false;
 		subtitles = [];
 		subtitlesCacheKey = null;
 		subtitlesWidget;

--- a/src/VideoHandler.ts
+++ b/src/VideoHandler.ts
@@ -220,6 +220,13 @@ export class VideoHandler {
   longWaitingResCount = 0;
   hadAsyncWait = false;
 
+  /**
+   * Set to `true` when the video was programmatically paused while waiting for
+   * translation audio to be prepared (autoPauseOnTranslate feature).
+   * Reset when translation finishes or when the user manually starts playback.
+   */
+  pausedByTranslation = false;
+
   // Available subtitle tracks for the current video. The subtitles UI widget
   // maintains its own internal line/token representation.
   subtitles: any[] = [];

--- a/src/localization/locales/af.json
+++ b/src/localization/locales/af.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Lewendige stemme",
   "VOTLiveVoicesSubtitle": "Maksimum ooreenkoms. Asof almal russies ken",
   "VOTYandexTokenExpired": "Sessie verstryk het. Meld weer aan",
-  "VOTVoiceSelection": "Kies dubbing"
+  "VOTVoiceSelection": "Kies dubbing",
+  "VOTAutoPauseOnTranslate": "Pouse video totdat vertaling gereed is"
 }

--- a/src/localization/locales/am.json
+++ b/src/localization/locales/am.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "የቀጥታ ድምጾች",
   "VOTLiveVoicesSubtitle": "ከፍተኛው ተመሳሳይነት. ሁሉም ሰው ሩሲያኛ ያውቃል ከሆነ እንደ",
   "VOTYandexTokenExpired": "ስብሰባው አብቅቷል። እንደገና ይግቡ",
-  "VOTVoiceSelection": "ዱባይን ይምረጡ"
+  "VOTVoiceSelection": "ዱባይን ይምረጡ",
+  "VOTAutoPauseOnTranslate": "ትርጉም ዝግጁ እስኪሆን ድረስ ቪዲዮ ለአፍታ ያቁሙ"
 }

--- a/src/localization/locales/ar.json
+++ b/src/localization/locales/ar.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "أصوات حية",
   "VOTLiveVoicesSubtitle": "التشابه الأقصى. كما لو أن الجميع يعرف الروسية",
   "VOTYandexTokenExpired": "انتهت الجلسة. تسجيل الدخول مرة أخرى",
-  "VOTVoiceSelection": "اختر الدبلجة"
+  "VOTVoiceSelection": "اختر الدبلجة",
+  "VOTAutoPauseOnTranslate": "إيقاف الفيديو مؤقتا حتى تصبح الترجمة جاهزة"
 }

--- a/src/localization/locales/az.json
+++ b/src/localization/locales/az.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Canlı səslər",
   "VOTLiveVoicesSubtitle": "Maksimum oxşarlıq. Sanki hamı rus dilini bilir",
   "VOTYandexTokenExpired": "Sessiya bitdi. Yenidən daxil olun",
-  "VOTVoiceSelection": "Dublyaj seçin"
+  "VOTVoiceSelection": "Dublyaj seçin",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/bg.json
+++ b/src/localization/locales/bg.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Живи гласове",
   "VOTLiveVoicesSubtitle": "Максимално сходство. Сякаш всички знаят руски.",
   "VOTYandexTokenExpired": "Сесията изтече. Влезте отново",
-  "VOTVoiceSelection": "Изберете дублаж"
+  "VOTVoiceSelection": "Изберете дублаж",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/bn.json
+++ b/src/localization/locales/bn.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "লাইভ ভয়েসেস",
   "VOTLiveVoicesSubtitle": "সর্বাধিক সাদৃশ্য. যেন সবাই রাশিয়ান জানে",
   "VOTYandexTokenExpired": "অধিবেশন শেষ আবার লগ ইন করুন",
-  "VOTVoiceSelection": "ডাবিং চয়ন করুন"
+  "VOTVoiceSelection": "ডাবিং চয়ন করুন",
+  "VOTAutoPauseOnTranslate": "অনুবাদ প্রস্তুত না হওয়া পর্যন্ত ভিডিও বিরতি দিন"
 }

--- a/src/localization/locales/bs.json
+++ b/src/localization/locales/bs.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Živi glasovi",
   "VOTLiveVoicesSubtitle": "Maksimalna sličnost. Kao da svi znaju ruski",
   "VOTYandexTokenExpired": "Sesija je istekla. Prijavite se ponovo",
-  "VOTVoiceSelection": "Odaberite sinhronizaciju"
+  "VOTVoiceSelection": "Odaberite sinhronizaciju",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/ca.json
+++ b/src/localization/locales/ca.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Veus en directe",
   "VOTLiveVoicesSubtitle": "Màxima similitud. Com si tothom conegués el rus",
   "VOTYandexTokenExpired": "Sessió expirada. Inicia sessió de nou",
-  "VOTVoiceSelection": "Tria doblatge"
+  "VOTVoiceSelection": "Tria doblatge",
+  "VOTAutoPauseOnTranslate": "Pausa el vídeo fins que la traducció estigui preparada"
 }

--- a/src/localization/locales/cs.json
+++ b/src/localization/locales/cs.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Živé hlasy",
   "VOTLiveVoicesSubtitle": "Maximální podobnost. Jako by každý věděl rusky",
   "VOTYandexTokenExpired": "Relace vypršela. Přihlásit se znovu",
-  "VOTVoiceSelection": "Vyberte si Dabing"
+  "VOTVoiceSelection": "Vyberte si Dabing",
+  "VOTAutoPauseOnTranslate": "Pozastavte video, dokud nebude překlad připraven"
 }

--- a/src/localization/locales/cy.json
+++ b/src/localization/locales/cy.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Lleisiau byw",
   "VOTLiveVoicesSubtitle": "Tebygrwydd mwyaf. Fel pe bai pawb yn gwybod rwsieg",
   "VOTYandexTokenExpired": "Daeth y sesiwn i ben. Mewngofnodi eto",
-  "VOTVoiceSelection": "Dewiswch dybio"
+  "VOTVoiceSelection": "Dewiswch dybio",
+  "VOTAutoPauseOnTranslate": "Seibio fideo nes bod y cyfieithiad yn barod"
 }

--- a/src/localization/locales/da.json
+++ b/src/localization/locales/da.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Levende stemmer",
   "VOTLiveVoicesSubtitle": "Maksimal lighed. Som om alle kender russisk",
   "VOTYandexTokenExpired": "Sessionen er udløbet. Log ind igen",
-  "VOTVoiceSelection": "Vælg dubbing"
+  "VOTVoiceSelection": "Vælg dubbing",
+  "VOTAutoPauseOnTranslate": "Pause video, indtil oversættelsen er klar"
 }

--- a/src/localization/locales/de.json
+++ b/src/localization/locales/de.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Live Stimmen",
   "VOTLiveVoicesSubtitle": "Maximale Ähnlichkeit. Als ob jeder Russisch kann",
   "VOTYandexTokenExpired": "Sitzung abgelaufen. Erneut anmelden",
-  "VOTVoiceSelection": "Wählen Sie Synchronisation"
+  "VOTVoiceSelection": "Wählen Sie Synchronisation",
+  "VOTAutoPauseOnTranslate": "Video anhalten, bis die Übersetzung fertig ist"
 }

--- a/src/localization/locales/el.json
+++ b/src/localization/locales/el.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Ζωντανές φωνές",
   "VOTLiveVoicesSubtitle": "Μέγιστη ομοιότητα. Σαν να γνωρίζουν όλοι ρωσική",
   "VOTYandexTokenExpired": "Η συνεδρία έληξε. Συνδεθείτε ξανά",
-  "VOTVoiceSelection": "Επιλέξτε μεταγλώττιση"
+  "VOTVoiceSelection": "Επιλέξτε μεταγλώττιση",
+  "VOTAutoPauseOnTranslate": "Παύση βίντεο μέχρι να είναι έτοιμη η μετάφραση"
 }

--- a/src/localization/locales/en.json
+++ b/src/localization/locales/en.json
@@ -20,6 +20,7 @@
   "VOTFailedDownloadAudio": "Failed to download audio",
   "audioFormatNotSupported": "The audio format is not supported",
   "VOTAutoTranslate": "Translate on open",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready",
   "VOTAutoSubtitles": "Subtitles on open",
   "VOTDontTranslateYourLang": "Don't translate from my language",
   "VOTVolume": "Video volume:",

--- a/src/localization/locales/es.json
+++ b/src/localization/locales/es.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Voces en vivo",
   "VOTLiveVoicesSubtitle": "Máxima similitud. Como si todo el mundo supiera ruso",
   "VOTYandexTokenExpired": "La sesión expiró. Inicie sesión de nuevo",
-  "VOTVoiceSelection": "Elegir doblaje"
+  "VOTVoiceSelection": "Elegir doblaje",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/et.json
+++ b/src/localization/locales/et.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Elavad hääled",
   "VOTLiveVoicesSubtitle": "Maksimaalne sarnasus. Nagu kõik teaksid vene keelt",
   "VOTYandexTokenExpired": "Seanss on aegunud. Logi uuesti sisse",
-  "VOTVoiceSelection": "Valige dubleerimine"
+  "VOTVoiceSelection": "Valige dubleerimine",
+  "VOTAutoPauseOnTranslate": "Peatage video, kuni tõlge on valmis"
 }

--- a/src/localization/locales/eu.json
+++ b/src/localization/locales/eu.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Bizi ahotsak",
   "VOTLiveVoicesSubtitle": "Antzekotasun handiena. Denek errusiera dakite",
   "VOTYandexTokenExpired": "Saioa amaitu da. Saioa hasi berriro",
-  "VOTVoiceSelection": "Aukeratu bikoizketa"
+  "VOTVoiceSelection": "Aukeratu bikoizketa",
+  "VOTAutoPauseOnTranslate": "Pausatu bideoa itzulpena prest dagoen arte"
 }

--- a/src/localization/locales/fa.json
+++ b/src/localization/locales/fa.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "صداهای زنده",
   "VOTLiveVoicesSubtitle": "حداکثر شباهت. گویی همه روسی می دانند",
   "VOTYandexTokenExpired": "جلسه منقضی شد. دوباره وارد شوید",
-  "VOTVoiceSelection": "دوبله را انتخاب کنید"
+  "VOTVoiceSelection": "دوبله را انتخاب کنید",
+  "VOTAutoPauseOnTranslate": "فیلم را مکث کنید تا ترجمه آماده شود"
 }

--- a/src/localization/locales/fi.json
+++ b/src/localization/locales/fi.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Live voices",
   "VOTLiveVoicesSubtitle": "Suurin samankaltaisuus. Aivan kuin kaikki osaisivat Venäjää",
   "VOTYandexTokenExpired": "Istunto päättyi. Kirjaudu sisään uudelleen",
-  "VOTVoiceSelection": "Valitse dubbaus"
+  "VOTVoiceSelection": "Valitse dubbaus",
+  "VOTAutoPauseOnTranslate": "Keskeytä video, Kunnes käännös on valmis"
 }

--- a/src/localization/locales/fr.json
+++ b/src/localization/locales/fr.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Voix en direct",
   "VOTLiveVoicesSubtitle": "Similitude maximale. Comme si tout le monde connaissait le russe",
   "VOTYandexTokenExpired": "La session a expiré. Connectez-vous à nouveau",
-  "VOTVoiceSelection": "Choisissez le doublage"
+  "VOTVoiceSelection": "Choisissez le doublage",
+  "VOTAutoPauseOnTranslate": "Mettez la vidéo en pause jusqu'à ce que la traduction soit prête"
 }

--- a/src/localization/locales/gl.json
+++ b/src/localization/locales/gl.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Voces en directo",
   "VOTLiveVoicesSubtitle": "Máxima similitude. Como se todos coñecesen o galego",
   "VOTYandexTokenExpired": "A sesión rematou. Entra de novo",
-  "VOTVoiceSelection": "Escoller o doblaxe"
+  "VOTVoiceSelection": "Escoller o doblaxe",
+  "VOTAutoPauseOnTranslate": "Pausa o vídeo ata que a tradución estea lista"
 }

--- a/src/localization/locales/hi.json
+++ b/src/localization/locales/hi.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "लाइव आवाज",
   "VOTLiveVoicesSubtitle": "अधिकतम समानता। जैसे कि हर कोई रूसी जानता है",
   "VOTYandexTokenExpired": "सत्र समाप्त हो गया ।  फिर से लॉग इन करें",
-  "VOTVoiceSelection": "डबिंग चुनें"
+  "VOTVoiceSelection": "डबिंग चुनें",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/hr.json
+++ b/src/localization/locales/hr.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Živi glasovi",
   "VOTLiveVoicesSubtitle": "Maksimalna sličnost. Kao da svi znaju ruski",
   "VOTYandexTokenExpired": "Sesija je istekla. Ponovno se prijavite",
-  "VOTVoiceSelection": "Odaberite presnimavanje"
+  "VOTVoiceSelection": "Odaberite presnimavanje",
+  "VOTAutoPauseOnTranslate": "Pauzirajte videozapis dok prijevod ne bude spreman"
 }

--- a/src/localization/locales/hu.json
+++ b/src/localization/locales/hu.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Élő hangok",
   "VOTLiveVoicesSubtitle": "Maximális hasonlóság. Mint ha mindenki tudja, orosz",
   "VOTYandexTokenExpired": "A munkamenet lejárt. Jelentkezzen be újra",
-  "VOTVoiceSelection": "Válassza ki a szinkronizálást"
+  "VOTVoiceSelection": "Válassza ki a szinkronizálást",
+  "VOTAutoPauseOnTranslate": "Szüneteltesse a videót, amíg a fordítás készen áll"
 }

--- a/src/localization/locales/hy.json
+++ b/src/localization/locales/hy.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Կենդանի ձայներ",
   "VOTLiveVoicesSubtitle": "Առավելագույն նմանություն: Կարծես բոլորը գիտեն ռուսերեն",
   "VOTYandexTokenExpired": "Նիստը լրացավ: Կրկին մուտք գործեք համակարգ",
-  "VOTVoiceSelection": "Ընտրեք կրկնօրինակ"
+  "VOTVoiceSelection": "Ընտրեք կրկնօրինակ",
+  "VOTAutoPauseOnTranslate": "Դադարեցրեք տեսանյութը, մինչև թարգմանությունը պատրաստ լինի"
 }

--- a/src/localization/locales/id.json
+++ b/src/localization/locales/id.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Suara langsung",
   "VOTLiveVoicesSubtitle": "Kesamaan maksimum. Seolah-olah semua orang tahu bahasa Rusia",
   "VOTYandexTokenExpired": "Sesi berakhir. Masuk lagi",
-  "VOTVoiceSelection": "Pilih sulih suara"
+  "VOTVoiceSelection": "Pilih sulih suara",
+  "VOTAutoPauseOnTranslate": "Jeda video hingga terjemahan siap"
 }

--- a/src/localization/locales/it.json
+++ b/src/localization/locales/it.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Voci dal vivo",
   "VOTLiveVoicesSubtitle": "Massima somiglianza. Come se tutti conoscessero il russo",
   "VOTYandexTokenExpired": "Sessione scaduta. Accedi di nuovo",
-  "VOTVoiceSelection": "Scegli il doppiaggio"
+  "VOTVoiceSelection": "Scegli il doppiaggio",
+  "VOTAutoPauseOnTranslate": "Mettere in pausa il video fino a quando la traduzione è pronta"
 }

--- a/src/localization/locales/ja.json
+++ b/src/localization/locales/ja.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "ライブボイス",
   "VOTLiveVoicesSubtitle": "最大の類似性。 誰もがロシア語を知っているかのように",
   "VOTYandexTokenExpired": "セッションの有効期限が切れました。 もう一度ログインします",
-  "VOTVoiceSelection": "ダビングを選ぶ"
+  "VOTVoiceSelection": "ダビングを選ぶ",
+  "VOTAutoPauseOnTranslate": "翻訳の準備が整うまでビデオを一時停止します"
 }

--- a/src/localization/locales/jv.json
+++ b/src/localization/locales/jv.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Swara urip",
   "VOTLiveVoicesSubtitle": "Kamiripan maksimal. Kaya-kaya kabèh wong ngerti basa rusia",
   "VOTYandexTokenExpired": "Sesi wis kadaluwarsa. Mlebu maneh",
-  "VOTVoiceSelection": "Milih dubbing"
+  "VOTVoiceSelection": "Milih dubbing",
+  "VOTAutoPauseOnTranslate": "Ngaso video nganti terjemahan siap"
 }

--- a/src/localization/locales/kk.json
+++ b/src/localization/locales/kk.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Тірі дауыстар",
   "VOTLiveVoicesSubtitle": "Максималды ұқсастық. Барлығы орыс тілін білетін сияқты",
   "VOTYandexTokenExpired": "Сессияның мерзімі аяқталды. Қайта кіріңіз",
-  "VOTVoiceSelection": "Дубляжды таңдаңыз"
+  "VOTVoiceSelection": "Дубляжды таңдаңыз",
+  "VOTAutoPauseOnTranslate": "Аударма дайын болғанша бейнені кідіртіңіз"
 }

--- a/src/localization/locales/km.json
+++ b/src/localization/locales/km.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "សំឡេងផ្ទាល់",
   "VOTLiveVoicesSubtitle": "ភាពស្រដៀងគ្នាអតិបរមា។ ដូចជាប្រសិនបើអ្នករាល់គ្នាដឹងរុស្ស៊ី",
   "VOTYandexTokenExpired": "សម័យដែលបានផុតកំណត់. ចូលម្តងទៀត",
-  "VOTVoiceSelection": "ជ្រើស dubbing"
+  "VOTVoiceSelection": "ជ្រើស dubbing",
+  "VOTAutoPauseOnTranslate": "ផ្អាកវីដេអូរហូតដល់ការបកប្រែរួចរាល់"
 }

--- a/src/localization/locales/kn.json
+++ b/src/localization/locales/kn.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "ಲೈವ್ ಧ್ವನಿಗಳು",
   "VOTLiveVoicesSubtitle": "ಗರಿಷ್ಠ ಹೋಲಿಕೆ. ಎಲ್ಲರಿಗೂ ರಷ್ಯನ್ ತಿಳಿದಿರುವಂತೆ",
   "VOTYandexTokenExpired": "ಅಧಿವೇಶನ ಮುಗಿದಿದೆ. ಮತ್ತೆ ಲಾಗ್ ಇನ್ ಮಾಡಿ",
-  "VOTVoiceSelection": "ಡಬ್ಬಿಂಗ್ ಆಯ್ಕೆ"
+  "VOTVoiceSelection": "ಡಬ್ಬಿಂಗ್ ಆಯ್ಕೆ",
+  "VOTAutoPauseOnTranslate": "ಅನುವಾದ ಸಿದ್ಧವಾಗುವವರೆಗೆ ವೀಡಿಯೊ ವಿರಾಮ"
 }

--- a/src/localization/locales/ko.json
+++ b/src/localization/locales/ko.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "라이브 보이스",
   "VOTLiveVoicesSubtitle": "최대 유사성. 모두가 러시아어를 알고있는 것처럼",
   "VOTYandexTokenExpired": "세션이 만료되었습니다. 다시 로그인",
-  "VOTVoiceSelection": "더빙 선택"
+  "VOTVoiceSelection": "더빙 선택",
+  "VOTAutoPauseOnTranslate": "번역이 준비 될 때까지 비디오 일시 중지"
 }

--- a/src/localization/locales/lo.json
+++ b/src/localization/locales/lo.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "ສຽງສົດ",
   "VOTLiveVoicesSubtitle": "ຄວາມຄ້າຍຄືກັນສູງສຸດ. ຄືກັບວ່າທຸກຄົນຮູ້ພາສາລັດເຊຍ",
   "VOTYandexTokenExpired": "ກອງປະຊຸມຫມົດອາຍຸ. ເຂົ້າສູ່ລະບົບອີກຄັ້ງ",
-  "VOTVoiceSelection": "ເລືອກ dubbing"
+  "VOTVoiceSelection": "ເລືອກ dubbing",
+  "VOTAutoPauseOnTranslate": "ຢຸດວິດີໂອຈົນກ່ວາການແປພາສາແມ່ນກຽມພ້ອມ"
 }

--- a/src/localization/locales/mk.json
+++ b/src/localization/locales/mk.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Гласови во живо",
   "VOTLiveVoicesSubtitle": "Максимална сличност. Како секој да знае руски",
   "VOTYandexTokenExpired": "Сесијата истече. Пријавете се повторно",
-  "VOTVoiceSelection": "Изберете синхронизација"
+  "VOTVoiceSelection": "Изберете синхронизација",
+  "VOTAutoPauseOnTranslate": "Паузирајте видео додека преводот не е подготвен"
 }

--- a/src/localization/locales/ml.json
+++ b/src/localization/locales/ml.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "ലൈവ് ശബ്ദങ്ങൾ",
   "VOTLiveVoicesSubtitle": "പരമാവധി സമാനത. എല്ലാവരും റഷ്യൻ അറിയുന്നു പോലെ",
   "VOTYandexTokenExpired": "സെഷൻ അവസാനിച്ചു. വീണ്ടും ലോഗിൻ ചെയ്യുക",
-  "VOTVoiceSelection": "ഡബ്ബിംഗ് തിരഞ്ഞെടുക്കുക"
+  "VOTVoiceSelection": "ഡബ്ബിംഗ് തിരഞ്ഞെടുക്കുക",
+  "VOTAutoPauseOnTranslate": "പരിഭാഷ തയ്യാറാകുന്നതുവരെ വീഡിയോ താൽക്കാലികമായി നിർത്തുക"
 }

--- a/src/localization/locales/mn.json
+++ b/src/localization/locales/mn.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Амьд дуу хоолой",
   "VOTLiveVoicesSubtitle": "Хамгийн их төстэй. Хэрэв хүн бүр мэддэг орос",
   "VOTYandexTokenExpired": "Хуралдаан дууссан. Дахин нэвтрэх",
-  "VOTVoiceSelection": "Дубляж сонгох"
+  "VOTVoiceSelection": "Дубляж сонгох",
+  "VOTAutoPauseOnTranslate": "Орчуулга бэлэн болтол видеог түр зогсоо"
 }

--- a/src/localization/locales/ms.json
+++ b/src/localization/locales/ms.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Hidup suara-suara",
   "VOTLiveVoicesSubtitle": "Persamaan maksimum. Seolah-olah semua orang tahu Rusia",
   "VOTYandexTokenExpired": "Sesi tamat. Log masuk lagi",
-  "VOTVoiceSelection": "Pilih Alih Suara"
+  "VOTVoiceSelection": "Pilih Alih Suara",
+  "VOTAutoPauseOnTranslate": "Jeda video sehingga terjemahan siap"
 }

--- a/src/localization/locales/mt.json
+++ b/src/localization/locales/mt.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Vuċijiet ħajjin",
   "VOTLiveVoicesSubtitle": "Xebh massimu. Bħallikieku kulħadd jaf ir russu",
   "VOTYandexTokenExpired": "Sessjoni skada. Idħol mill-ġdid",
-  "VOTVoiceSelection": "Agħżel id-doppjaġġ"
+  "VOTVoiceSelection": "Agħżel id-doppjaġġ",
+  "VOTAutoPauseOnTranslate": "Nieqaf il-vidjow sakemm it-traduzzjoni tkun lesta"
 }

--- a/src/localization/locales/my.json
+++ b/src/localization/locales/my.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "တိုက်ရိုက်အသံများ",
   "VOTLiveVoicesSubtitle": "အများဆုံးတူညီမှုပါ။ လူတိုင်းကရုရှားလိုသိနေသလိုပေါ့။",
   "VOTYandexTokenExpired": "အစည်းအဝေးကပြီးသွားပြီ။ နောက်တစ်ကြိမ်ပြန်လည်ဝင်ရောက်",
-  "VOTVoiceSelection": "Dubbing ကိုရွေးပါ။"
+  "VOTVoiceSelection": "Dubbing ကိုရွေးပါ။",
+  "VOTAutoPauseOnTranslate": "ဘာသာပြန်မှုအဆင်သင့်ဖြစ်သည်အထိဗီဒီယိုကိုရပ်ထားပါ။"
 }

--- a/src/localization/locales/ne.json
+++ b/src/localization/locales/ne.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "प्रत्यक्ष आवाजहरू",
   "VOTLiveVoicesSubtitle": "अधिकतम समानता मानौं सबैलाई रुसी भाषा थाहा छ",
   "VOTYandexTokenExpired": "सत्र समाप्त भयो ।  फेरि लग इन गर्नुहोस्",
-  "VOTVoiceSelection": "डबिंग रोज्नुहोस्"
+  "VOTVoiceSelection": "डबिंग रोज्नुहोस्",
+  "VOTAutoPauseOnTranslate": "अनुवाद तयार नभएसम्म भिडियो पज गर्नुहोस्"
 }

--- a/src/localization/locales/nl.json
+++ b/src/localization/locales/nl.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Live voices",
   "VOTLiveVoicesSubtitle": "Maximale gelijkenis. Alsof iedereen Russisch kent",
   "VOTYandexTokenExpired": "Sessie verlopen. Opnieuw inloggen",
-  "VOTVoiceSelection": "Kies dubbing"
+  "VOTVoiceSelection": "Kies dubbing",
+  "VOTAutoPauseOnTranslate": "Video pauzeren tot de vertaling klaar is"
 }

--- a/src/localization/locales/pa.json
+++ b/src/localization/locales/pa.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "ਲਾਈਵ ਆਵਾਜ਼ਾਂ",
   "VOTLiveVoicesSubtitle": "ਵੱਧ ਤੋਂ ਵੱਧ ਸਮਾਨਤਾ ਜਿਵੇਂ ਕਿ ਹਰ ਕੋਈ ਰੂਸੀ ਜਾਣਦਾ ਹੈ",
   "VOTYandexTokenExpired": "ਸੈਸ਼ਨ ਖਤਮ ਹੋ ਗਿਆ ਹੈ. ਮੁੜ ਲਾਗਇਨ ਕਰੋ",
-  "VOTVoiceSelection": "ਡਬਿੰਗ ਚੁਣੋ"
+  "VOTVoiceSelection": "ਡਬਿੰਗ ਚੁਣੋ",
+  "VOTAutoPauseOnTranslate": "ਅਨੁਵਾਦ ਤਿਆਰ ਹੋਣ ਤੱਕ ਵਿਡੀਓ ਵਿਰਾਮ ਕਰੋ"
 }

--- a/src/localization/locales/pl.json
+++ b/src/localization/locales/pl.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Głosy na żywo",
   "VOTLiveVoicesSubtitle": "Maksymalne podobieństwo. Jakby wszyscy znali rosyjski",
   "VOTYandexTokenExpired": "Sesja wygasła. Zaloguj się ponownie",
-  "VOTVoiceSelection": "Wybierz dubbing"
+  "VOTVoiceSelection": "Wybierz dubbing",
+  "VOTAutoPauseOnTranslate": "Wstrzymaj wideo, aż tłumaczenie będzie gotowe"
 }

--- a/src/localization/locales/pt.json
+++ b/src/localization/locales/pt.json
@@ -250,5 +250,6 @@
   "VOTLiveVoicesTitle": "Vozes ao vivo",
   "VOTLiveVoicesSubtitle": "O máximo de semelhança. Como se todos soubessem russo",
   "VOTYandexTokenExpired": "A sessão expirou. Iniciar sessão novamente",
-  "VOTVoiceSelection": "Escolha a dublagem"
+  "VOTVoiceSelection": "Escolha a dublagem",
+  "VOTAutoPauseOnTranslate": "Pausar o vídeo até que a tradução esteja pronta"
 }

--- a/src/localization/locales/ro.json
+++ b/src/localization/locales/ro.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Voci Live",
   "VOTLiveVoicesSubtitle": "Similitudine maximă. Ca și cum toată lumea știe limba rusă",
   "VOTYandexTokenExpired": "Sesiunea a expirat. Conectați-vă din nou",
-  "VOTVoiceSelection": "Alegeți dublarea"
+  "VOTVoiceSelection": "Alegeți dublarea",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/ru.json
+++ b/src/localization/locales/ru.json
@@ -251,5 +251,6 @@
   "subtitlesSmartLayout": "Умное расположение субтитров",
   "smartDucking": "Адаптивная громкость",
   "VOTYandexTokenExpired": "Сессия истекла. Войдите снова",
-  "VOTVoiceSelection": "Выбрать озвучку"
+  "VOTVoiceSelection": "Выбрать озвучку",
+  "VOTAutoPauseOnTranslate": "Приостанавливать видео до готовности перевода"
 }

--- a/src/localization/locales/si.json
+++ b/src/localization/locales/si.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "සජීවී හඬවල්",
   "VOTLiveVoicesSubtitle": "උපරිම සමානතාවය. හැමෝම රුසියානු දන්නවා වගේ",
   "VOTYandexTokenExpired": "සැසිය කල් ඉකුත් විය. නැවත පිවිසෙන්න",
-  "VOTVoiceSelection": "ඩබ් කිරීම තෝරන්න"
+  "VOTVoiceSelection": "ඩබ් කිරීම තෝරන්න",
+  "VOTAutoPauseOnTranslate": "පරිවර්තනය සූදානම් වන තුරු වීඩියෝ විරාමයක්"
 }

--- a/src/localization/locales/sk.json
+++ b/src/localization/locales/sk.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Živé hlasy",
   "VOTLiveVoicesSubtitle": "Maximálna podobnosť. Ako keby každý vedel rusky",
   "VOTYandexTokenExpired": "Platnosť relácie vypršala. Prihlásiť sa",
-  "VOTVoiceSelection": "Vyberte dabing"
+  "VOTVoiceSelection": "Vyberte dabing",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/sl.json
+++ b/src/localization/locales/sl.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Glasovi v živo",
   "VOTLiveVoicesSubtitle": "Največja podobnost. Kot da vsi vedo rusko",
   "VOTYandexTokenExpired": "Seja je potekla. Ponovno se prijavite",
-  "VOTVoiceSelection": "Izberite sinhronizacijo"
+  "VOTVoiceSelection": "Izberite sinhronizacijo",
+  "VOTAutoPauseOnTranslate": "Začasno ustavite video, dokler prevod ni pripravljen"
 }

--- a/src/localization/locales/sq.json
+++ b/src/localization/locales/sq.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Zërat e gjallë",
   "VOTLiveVoicesSubtitle": "Ngjashmëria maksimale. Sikur të gjithë e dinë rusisht",
   "VOTYandexTokenExpired": "Seanca skadoi. Hyni përsëri",
-  "VOTVoiceSelection": "Zgjidhni dublimin"
+  "VOTVoiceSelection": "Zgjidhni dublimin",
+  "VOTAutoPauseOnTranslate": "Ndaloni videon derisa përkthimi të jetë gati"
 }

--- a/src/localization/locales/sr.json
+++ b/src/localization/locales/sr.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Живи гласови",
   "VOTLiveVoicesSubtitle": "Максимална сличност. Као да сви знају руски",
   "VOTYandexTokenExpired": "Сесија је истекла. Поново се пријавите",
-  "VOTVoiceSelection": "Изаберите дуб"
+  "VOTVoiceSelection": "Изаберите дуб",
+  "VOTAutoPauseOnTranslate": "Паузирајте видео док превод не буде спреман"
 }

--- a/src/localization/locales/su.json
+++ b/src/localization/locales/su.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Sora nu hirup",
   "VOTLiveVoicesSubtitle": "Kamiripan maksimum. Seolah olah semuanya tahu rusia",
   "VOTYandexTokenExpired": "Sesi kadaluarsa. Asup deui",
-  "VOTVoiceSelection": "Pilih dubbing"
+  "VOTVoiceSelection": "Pilih dubbing",
+  "VOTAutoPauseOnTranslate": "Jeda video nepi panarjamahan geus siap"
 }

--- a/src/localization/locales/sv.json
+++ b/src/localization/locales/sv.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Levande röster",
   "VOTLiveVoicesSubtitle": "Maximal likhet. Som om alla vet ryska",
   "VOTYandexTokenExpired": "Sessionen har gått ut. Logga in igen",
-  "VOTVoiceSelection": "Välj dubbning"
+  "VOTVoiceSelection": "Välj dubbning",
+  "VOTAutoPauseOnTranslate": "Pausa videon Tills översättningen är klar"
 }

--- a/src/localization/locales/sw.json
+++ b/src/localization/locales/sw.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Sauti za moja kwa moja",
   "VOTLiveVoicesSubtitle": "Kufanana kwa kiwango cha juu. Kama kila mtu anajua kirusi",
   "VOTYandexTokenExpired": "Kipindi kiliisha. Ingia tena",
-  "VOTVoiceSelection": "Chagua dubbing"
+  "VOTVoiceSelection": "Chagua dubbing",
+  "VOTAutoPauseOnTranslate": "Pumzika video mpaka tafsiri iko tayari"
 }

--- a/src/localization/locales/tr.json
+++ b/src/localization/locales/tr.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Canlı sesler",
   "VOTLiveVoicesSubtitle": "Maksimum benzerlik. Sanki herkes Rusça biliyormuş gibi",
   "VOTYandexTokenExpired": "Oturumun süresi doldu. Tekrar giriş yap",
-  "VOTVoiceSelection": "Dublajı seçin"
+  "VOTVoiceSelection": "Dublajı seçin",
+  "VOTAutoPauseOnTranslate": "Çeviri hazır olana kadar videoyu duraklatın"
 }

--- a/src/localization/locales/uk.json
+++ b/src/localization/locales/uk.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Живі голоси",
   "VOTLiveVoicesSubtitle": "Максимальна схожість. Наче всі знають російську",
   "VOTYandexTokenExpired": "Сеанс закінчився. Увійдіть ще раз",
-  "VOTVoiceSelection": "Виберіть дубляж"
+  "VOTVoiceSelection": "Виберіть дубляж",
+  "VOTAutoPauseOnTranslate": "Призупиніть Відео, поки переклад не буде готовий"
 }

--- a/src/localization/locales/ur.json
+++ b/src/localization/locales/ur.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "لائیو آوازیں",
   "VOTLiveVoicesSubtitle": "زیادہ سے زیادہ مماثلت. گویا ہر کوئی روسی جانتا ہے ۔ ",
   "VOTYandexTokenExpired": "سیشن ختم ہو گیا. دوبارہ لاگ ان کریں",
-  "VOTVoiceSelection": "ڈبنگ کا انتخاب کریں"
+  "VOTVoiceSelection": "ڈبنگ کا انتخاب کریں",
+  "VOTAutoPauseOnTranslate": "Pause video until translation is ready"
 }

--- a/src/localization/locales/uz.json
+++ b/src/localization/locales/uz.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Jonli ovozlar",
   "VOTLiveVoicesSubtitle": "Maksimal o'xshashlik. Go'yo hamma rus tilini biladi",
   "VOTYandexTokenExpired": "Sessiya muddati tugadi. Qayta kiring",
-  "VOTVoiceSelection": "Dublyajni tanlang"
+  "VOTVoiceSelection": "Dublyajni tanlang",
+  "VOTAutoPauseOnTranslate": "Tarjima tayyor bo'lgunga qadar videoni pauza qiling"
 }

--- a/src/localization/locales/vi.json
+++ b/src/localization/locales/vi.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Giọng nói trực tiếp",
   "VOTLiveVoicesSubtitle": "Sự tương đồng tối đa. Như thể mọi người đều biết tiếng nga",
   "VOTYandexTokenExpired": "Phiên hết hạn. Đăng nhập lại",
-  "VOTVoiceSelection": "Chọn lồng tiếng"
+  "VOTVoiceSelection": "Chọn lồng tiếng",
+  "VOTAutoPauseOnTranslate": "Tạm dừng video cho đến khi bản dịch đã sẵn sàng"
 }

--- a/src/localization/locales/zh.json
+++ b/src/localization/locales/zh.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "现场声音",
   "VOTLiveVoicesSubtitle": "最大相似度。 好像每个人都知道俄语",
   "VOTYandexTokenExpired": "会话过期。 再次登入",
-  "VOTVoiceSelection": "选择配音"
+  "VOTVoiceSelection": "选择配音",
+  "VOTAutoPauseOnTranslate": "暂停视频，直到翻译准备好"
 }

--- a/src/localization/locales/zu.json
+++ b/src/localization/locales/zu.json
@@ -251,5 +251,6 @@
   "VOTLiveVoicesTitle": "Amazwi aphilayo",
   "VOTLiveVoicesSubtitle": "Ukufana okuphezulu. Njengokungathi wonke umuntu uyazi isirashiya",
   "VOTYandexTokenExpired": "Isikhathi sesiphelile. Ngena futhi",
-  "VOTVoiceSelection": "Choose dubbing"
+  "VOTVoiceSelection": "Choose dubbing",
+  "VOTAutoPauseOnTranslate": "Phumula ividiyo kuze translation isilungile"
 }

--- a/src/types/localization.ts
+++ b/src/types/localization.ts
@@ -89,6 +89,7 @@ export type Phrase =
   | "VOTFailedDownloadAudio"
   | "audioFormatNotSupported"
   | "VOTAutoTranslate"
+  | "VOTAutoPauseOnTranslate"
   | "VOTAutoSubtitles"
   | "VOTDontTranslateYourLang"
   | "VOTVolume"
@@ -339,6 +340,7 @@ export type Phrases = {
   VOTFailedDownloadAudio: string;
   audioFormatNotSupported: string;
   VOTAutoTranslate: string;
+  VOTAutoPauseOnTranslate: string;
   VOTAutoSubtitles: string;
   VOTDontTranslateYourLang: string;
   VOTVolume: string;
@@ -575,3 +577,9 @@ export type Phrases = {
 };
 
 export type FlatPhrases = Record<Phrase, string>;
+
+/**
+ * Language override for the extension menu.
+ * `"auto"` means use the browser's language.
+ */
+export type LangOverride = "auto" | Locale;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -25,6 +25,7 @@ export type ConvertData = Record<ConvertCategory, ConvertDataItem[]>;
 
 export const storageKeys = [
   "autoTranslate",
+  "autoPauseOnTranslate",
   "autoSubtitles",
   "dontTranslateLanguages",
   "enabledDontTranslateLanguages",
@@ -84,6 +85,11 @@ export type Account = {
 
 export type StorageData = {
   autoTranslate: boolean;
+  /**
+   * Pause the video while translation is being prepared,
+   * then auto-play once the translated audio is ready.
+   */
+  autoPauseOnTranslate: boolean;
   autoSubtitles: boolean;
   dontTranslateLanguages: LanguageSelectKey[];
   enabledDontTranslateLanguages: boolean;

--- a/src/types/views/settings.ts
+++ b/src/types/views/settings.ts
@@ -20,6 +20,7 @@ export type SettingsViewEventMap = {
   "click:resetSettings": [];
   "update:account": [account: Partial<Account> | undefined];
   "change:autoTranslate": [checked: boolean];
+  "change:autoPauseOnTranslate": [checked: boolean];
   "change:autoSubtitles": [checked: boolean];
   "change:showVideoVolume": [checked: boolean];
   "change:audioBooster": [checked: boolean];

--- a/src/ui/views/settings.ts
+++ b/src/ui/views/settings.ts
@@ -7,6 +7,7 @@ const SETTINGS_EVENT_KEYS: Array<keyof SettingsViewEventMap> = [
   "click:resetSettings",
   "update:account",
   "change:autoTranslate",
+  "change:autoPauseOnTranslate",
   "change:autoSubtitles",
   "change:showVideoVolume",
   "change:audioBooster",
@@ -220,6 +221,7 @@ export class SettingsView {
   accountButtonTokenTooltip?: Tooltip;
   private accountStorageListenerCleanup?: () => void;
   autoTranslateCheckbox?: Checkbox;
+  autoPauseOnTranslateCheckbox?: Checkbox;
   autoSubtitlesCheckbox?: Checkbox;
   dontTranslateLanguagesCheckbox?: Checkbox;
   dontTranslateLanguagesSelect?: Select<LanguageSelectKey, true>;
@@ -672,6 +674,10 @@ export class SettingsView {
       labelHtml: localizationProvider.get("VOTAutoTranslate"),
       checked: this.data.autoTranslate,
     });
+    this.autoPauseOnTranslateCheckbox = new Checkbox({
+      labelHtml: localizationProvider.get("VOTAutoPauseOnTranslate"),
+      checked: this.data.autoPauseOnTranslate,
+    });
     this.autoSubtitlesCheckbox = new Checkbox({
       labelHtml: localizationProvider.get("VOTAutoSubtitles"),
       checked: this.data.autoSubtitles,
@@ -774,6 +780,7 @@ export class SettingsView {
     accountSection.content.append(this.accountButton.container);
     translationSection.content.append(
       this.autoTranslateCheckbox.container,
+      this.autoPauseOnTranslateCheckbox.container,
       this.autoSubtitlesCheckbox.container,
       this.dontTranslateLanguagesSelect.container,
       this.autoSetVolumeSlider.container,
@@ -1182,6 +1189,18 @@ export class SettingsView {
       logLabel: "autoTranslate",
       dispatch: (checked) =>
         this.events["change:autoTranslate"].dispatch(checked),
+    });
+    this.bindPersistedSetting({
+      control: this.autoPauseOnTranslateCheckbox,
+      event: "change",
+      apply: (checked) => {
+        this.data.autoPauseOnTranslate = checked;
+      },
+      storageKey: "autoPauseOnTranslate",
+      readPersistedValue: () => this.data.autoPauseOnTranslate,
+      logLabel: "autoPauseOnTranslate",
+      dispatch: (checked) =>
+        this.events["change:autoPauseOnTranslate"].dispatch(checked),
     });
     this.bindPersistedSetting({
       control: this.autoSubtitlesCheckbox,

--- a/src/videoHandler/modules/init.ts
+++ b/src/videoHandler/modules/init.ts
@@ -52,6 +52,7 @@ export async function init(this: VideoHandler) {
   // Retrieve settings from storage.
   this.data = await votStorage.getValues({
     autoTranslate: false,
+    autoPauseOnTranslate: false,
     autoSubtitles: false,
     dontTranslateLanguages: [calculatedResLang],
     enabledDontTranslateLanguages: true,

--- a/src/videoHandler/modules/translationPlayback.ts
+++ b/src/videoHandler/modules/translationPlayback.ts
@@ -596,6 +596,18 @@ export async function translateFunc(
       return;
     }
 
+    // Auto-pause: pause video while waiting for translation to be prepared.
+    // Skip if the translation is already cached (handled above).
+    if (
+      this.data?.autoPauseOnTranslate &&
+      !this.video.paused &&
+      !this.video.ended
+    ) {
+      debug.log("[translateFunc] Pausing video until translation is ready");
+      this.pausedByTranslation = true;
+      this.video.pause();
+    }
+
     const translateRes = await requestApplyAndCacheTranslation(this, {
       videoData,
       requestLang: reqLang,
@@ -667,6 +679,19 @@ export async function translateFunc(
     if (this.activeTranslation?.promise === translationPromise) {
       this.activeTranslation = null;
     }
+
+    // Auto-pause: resume playback once the translated audio is ready
+    // (or on failure/abort). Only resume if we were the ones who paused.
+    if (this.pausedByTranslation) {
+      this.pausedByTranslation = false;
+      if (this.hasActiveSource()) {
+        debug.log("[translateFunc] Resuming video after translation is ready");
+        this.video.play().catch((playErr) => {
+          debug.log("[translateFunc] Failed to resume video", playErr);
+        });
+      }
+    }
+
     const overlayBtn = this.uiManager.votOverlayView?.votButton;
     if (
       !this.activeTranslation &&

--- a/src/videoHandler/modules/translationPlayback.ts
+++ b/src/videoHandler/modules/translationPlayback.ts
@@ -1,4 +1,4 @@
-﻿import type { RequestLang, ResponseLang } from "@vot.js/shared/types/data";
+import type { RequestLang, ResponseLang } from "@vot.js/shared/types/data";
 
 import { isTranslationDownloadHost } from "../../core/hostPolicies";
 import { notifyTranslationFailureIfNeeded } from "../../core/translationErrors";
@@ -605,6 +605,13 @@ export async function translateFunc(
     ) {
       debug.log("[translateFunc] Pausing video until translation is ready");
       this.pausedByTranslation = true;
+      this.video.addEventListener(
+        "play",
+        () => {
+          this.pausedByTranslation = false;
+        },
+        { once: true },
+      );
       this.video.pause();
     }
 
@@ -681,8 +688,9 @@ export async function translateFunc(
     }
 
     // Auto-pause: resume playback once the translated audio is ready
-    // (or on failure/abort). Only resume if we were the ones who paused.
-    if (this.pausedByTranslation) {
+    // (or on failure/abort). Only resume if we were the ones who paused,
+    // and if we are still the active translation (to prevent aborted requests from resuming).
+    if (!this.activeTranslation && this.pausedByTranslation) {
       this.pausedByTranslation = false;
       if (this.hasActiveSource()) {
         debug.log("[translateFunc] Resuming video after translation is ready");


### PR DESCRIPTION
## Description
This PR adds a new feature/setting to automatically pause the video while a translation is being prepared, and then automatically play/resume the video once the translation has finished loading and is ready.

The setting is called `autoPauseOnTranslate` ("Pause video during translation preparation" / "Пауза при подготовке перевода") and is disabled by default.

**Use Case**: This is especially useful when watching playlists (e.g., courses, etc.). When the next video autoplays, this option ensures that the newly opened video is instantly paused to wait for the translation to be ready, and then automatically resumes playback once it is fully loaded.

## Changes
- **Storage & Config**: Added `autoPauseOnTranslate` key to `votStorage` defaults and Types.
- **UI Settings**: Added a new checkbox in the settings menu (bound to storage key `autoPauseOnTranslate`).
- **Playback Controller**: Implemented the auto-pause trigger right before requesting translation and auto-resume within the `finally` block when the translation loads successfully.
- **Localization**: Added the new translation string to all 62 locale JSON files, updated types in `localization.ts`, and regenerated hashes via the localization script.

## How to test
1. Open the extension/userscript settings.
2. Enable the option **"Pause video during translation preparation"**.
3. Open a video in a foreign language and trigger translation.
4. Verify that:
   - The video pauses immediately after clicking the translate button.
   - The video automatically resumes playback once the translation is ready.
