### PR TITLE
Исправление отключения перевода при быстрой перемотке видео (Firefox)

### DIFF
--- a/dist/vot.user.js
+++ b/dist/vot.user.js
@@ -7040,7 +7040,8 @@ var vot = (function(exports) {
 		"seeking",
 		"pause",
 		"ended",
-		"seeked"
+		"seeked",
+		"canplay"
 	];
 	var BUFFERING_PAUSE_DELAY_MS = 250;
 	var SYNC_DRIFT_TOLERANCE_SEC = .15;
@@ -7259,6 +7260,7 @@ var vot = (function(exports) {
 				case "play":
 				case "playing":
 				case "seeked":
+				case "canplay":
 					this.cancelBufferingPause();
 					this.isBuffering = false;
 					if (!this.chaimu.video.paused) this.syncPlay();
@@ -7444,6 +7446,7 @@ var vot = (function(exports) {
 				case "playing":
 				case "ratechange":
 				case "seeked":
+				case "canplay":
 					this.cancelBufferingPause();
 					this.isBuffering = false;
 					if (!this.chaimu.video.paused) this.start();
@@ -12738,10 +12741,15 @@ var vot = (function(exports) {
 			const hasSrcObject = this.host.video.srcObject ? "1" : "0";
 			if (this.host.site.host === "youtube") {
 				const path = globalThis.location.pathname;
-				return `${`${globalThis.location.origin}${path}${globalThis.location.search}`}||${hasSrcObject}`;
+				const u = new URL(globalThis.location.href);
+				u.searchParams.delete("t");
+				const cleaned = u.origin + path + (u.search || "");
+				return `${cleaned}||${hasSrcObject}`;
 			}
 			const src = this.host.video.currentSrc || this.host.video.src || "";
-			return `${globalThis.location.href}||${src}||${hasSrcObject}`;
+			const u = new URL(globalThis.location.href);
+			for (const p of ["t","start","end","time"]) u.searchParams.delete(p);
+			return `${u.href}||${src}||${hasSrcObject}`;
 		}
 		resolveContainer() {
 			const { site, video, container } = this.host;


### PR DESCRIPTION
Проблема: При быстром перемещении между частями видео, когда кеш ещё не подгрузился, перевод отключался — кнопка возвращалась в состояние «Translate».

Корневая причина: getCurrentSourceKey() включал location.search в ключ источника. На YouTube при клике на таймлайн в URL добавляется параметр ?t=XXX (позиция перемотки). Из-за этого после каждой перемотки source key менялся, handleSrcChanged срабатывал ложно, полагая, что сменилось видео, и вызывал stopTranslation(). На других сайтах аналогичную проблему могли вызывать параметры t, start, end, time.

Изменения в dist/vot.user.js (4 изменения)
1. videoLipSyncEvents — добавлено событие "canplay" Событие canplay не было в списке отслеживаемых событий видео. Когда кеш догружался после перемотки (readyState >= HAVE_FUTURE_DATA), аудио-плеер не получал уведомления и не возобновлял проигрывание.

2. AudioPlayer.lipSync — обработка "canplay" Добавлен case "canplay" в блок переключателя, обрабатывающий события возобновления. Логика та же, что у "playing"/"seeked": сброс флага буферизации, отмена таймера паузы и вызов syncPlay().

3. ChaimuPlayer.lipSync — обработка "canplay" Аналогичный case "canplay" для альтернативного плеера: cancelBufferingPause(), isBuffering = false, вызов start().

4. getCurrentSourceKey() — удаление параметров времени из URL Для YouTube: через URL.searchParams.delete("t") убирается параметр положения перемотки. Для остальных сайтов: удаляются параметры t, start, end, time из location.href. Это предотвращает ложное срабатывание handleSrcChanged при перемотке — source key остаётся стабильным для одного и того же видео.