### PR TITLE
fix: enable VOT on Coursera labs and other non-lecture items

### DIFF
--- a/scripts/wiki-gen/SITES-EN.md
+++ b/scripts/wiki-gen/SITES-EN.md
@@ -858,6 +858,8 @@ Available (sub)domains:
 Available paths:
 
 - /learn/NAME/lecture/XXXX
+- /learn/NAME/ungradedLab/XXXX
+- /learn/NAME/ITEM_TYPE/XXXX
 
 Limitations:
 

--- a/scripts/wiki-gen/SITES-RU.md
+++ b/scripts/wiki-gen/SITES-RU.md
@@ -858,6 +858,8 @@
 Доступные пути:
 
 - /learn/NAME/lecture/XXXX
+- /learn/NAME/ungradedLab/XXXX
+- /learn/NAME/ITEM_TYPE/XXXX
 
 Ограничения:
 

--- a/scripts/wiki-gen/data.js
+++ b/scripts/wiki-gen/data.js
@@ -142,7 +142,11 @@ const siteData = {
     paths: ["/video/VIDEO_ID", "/embed/VIDEO_ID"],
   },
   coursera: {
-    paths: ["/learn/NAME/lecture/XXXX"],
+    paths: [
+      "/learn/NAME/lecture/XXXX",
+      "/learn/NAME/ungradedLab/XXXX",
+      "/learn/NAME/ITEM_TYPE/XXXX",
+    ],
     limits: [locales.needBeLoggedIn, locales.videoWithoutSubs],
   },
   eporner: {

--- a/src/core/courseraSupport.ts
+++ b/src/core/courseraSupport.ts
@@ -1,0 +1,53 @@
+/**
+ * Coursera on-demand item types that can embed the same Video.js player
+ * as lectures. vot.js currently only parses `/lecture/` routes.
+ */
+export const COURSERA_VIDEO_ITEM_TYPES = [
+  "lecture",
+  "ungradedLab",
+  "ungradedWidget",
+  "supplement",
+  "programmingLab",
+  "programmingAssignment",
+  "notebook",
+  "lab",
+  "quiz",
+  "exam",
+  "peer",
+  "discussionPrompt",
+  "honors",
+  "staffGraded",
+  "assignment",
+  "review",
+  "workspaceLab",
+  "ungradedLti",
+  "gradedLti",
+] as const;
+
+const COURSERA_LEARN_ITEM_RE = new RegExp(
+  `learn/([^/]+)/(${COURSERA_VIDEO_ITEM_TYPES.join("|")})/([^/]+)`,
+);
+const COURSERA_PREVIEW_LECTURE_RE = /lecture\/([^/]+)\/([^/]+)/;
+const COURSERA_LEARN_SLUG_RE = /learn\/([^/]+)/;
+
+/**
+ * Returns the same ID shape as `@vot.js/ext` CourseraHelper for lectures:
+ * `learn/COURSE/lecture/ITEM_ID`. Also accepts labs and other item routes.
+ */
+export function getCourseraVideoIdFromPath(
+  pathname: string,
+): string | undefined {
+  return (
+    COURSERA_LEARN_ITEM_RE.exec(pathname)?.[0] ??
+    COURSERA_PREVIEW_LECTURE_RE.exec(pathname)?.[0]
+  );
+}
+
+export function getCourseraCourseSlugFromPath(
+  pathname: string,
+): string | undefined {
+  return (
+    COURSERA_LEARN_SLUG_RE.exec(pathname)?.[1] ??
+    COURSERA_PREVIEW_LECTURE_RE.exec(pathname)?.[1]
+  );
+}

--- a/src/core/courseraVideoData.ts
+++ b/src/core/courseraVideoData.ts
@@ -1,0 +1,111 @@
+import CourseraHelper from "@vot.js/ext/helpers/coursera";
+import type { ServiceConf } from "@vot.js/ext/types/service";
+import {
+  getVideoData,
+  getVideoID,
+} from "@vot.js/ext/utils/videoData";
+import debug from "../utils/debug";
+import { GM_fetch } from "../utils/gm";
+import {
+  getCourseraCourseSlugFromPath,
+  getCourseraVideoIdFromPath,
+} from "./courseraSupport";
+
+type SiteVideoData = Awaited<ReturnType<typeof getVideoData>>;
+
+type HelperPrototype = {
+  getVideoId: (url: URL) => Promise<string | undefined>;
+  getCourseSlug: () => string | undefined;
+};
+
+let courseraHelperPatched = false;
+
+/**
+ * Keep vot.js helper methods in sync when the same class instance is used
+ * internally by `getVideoID` / `getVideoData`.
+ */
+export function applyCourseraHelperPatch(): void {
+  if (courseraHelperPatched) {
+    return;
+  }
+  courseraHelperPatched = true;
+
+  const proto = CourseraHelper.prototype as unknown as HelperPrototype;
+  proto.getVideoId = async (url) => getCourseraVideoIdFromPath(url.pathname);
+  proto.getCourseSlug = () =>
+    getCourseraCourseSlugFromPath(globalThis.location.pathname);
+}
+
+applyCourseraHelperPatch();
+
+export async function getCourseraExtraVideoData(
+  service: ServiceConf,
+  opts: {
+    fetchFn?: typeof GM_fetch;
+    video?: HTMLVideoElement;
+    language?: string;
+  },
+): Promise<SiteVideoData | undefined> {
+  const videoId = getCourseraVideoIdFromPath(globalThis.location.pathname);
+  if (!videoId) {
+    return undefined;
+  }
+
+  const helper = new CourseraHelper({
+    ...opts,
+    service,
+    origin: globalThis.location.origin,
+  });
+  helper.getCourseSlug = () =>
+    getCourseraCourseSlugFromPath(globalThis.location.pathname);
+
+  const result = await helper.getVideoData(videoId);
+  if (!result?.url) {
+    debug.log("[VOT] Coursera helper returned no video url", { videoId });
+    return undefined;
+  }
+
+  debug.log("[VOT] Resolved Coursera video data", {
+    videoId,
+    hasTranslationHelp: Boolean(result.translationHelp?.length),
+  });
+
+  return {
+    ...result,
+    url: result.url,
+    videoId,
+    host: service.host,
+  } as SiteVideoData;
+}
+
+export async function resolveSiteVideoId(
+  site: ServiceConf,
+  video: HTMLVideoElement,
+): Promise<string | undefined> {
+  if (site.host === "coursera") {
+    const videoId = getCourseraVideoIdFromPath(globalThis.location.pathname);
+    if (videoId) {
+      return videoId;
+    }
+  }
+
+  return getVideoID(site, { fetchFn: GM_fetch, video });
+}
+
+export async function fetchSiteVideoData(
+  site: ServiceConf,
+  opts: {
+    fetchFn?: typeof GM_fetch;
+    video?: HTMLVideoElement;
+    language?: string;
+  },
+): Promise<SiteVideoData> {
+  if (site.host === "coursera") {
+    const courseraData = await getCourseraExtraVideoData(site, opts);
+    if (courseraData) {
+      return courseraData;
+    }
+  }
+
+  return getVideoData(site, opts);
+}

--- a/src/core/videoManager.ts
+++ b/src/core/videoManager.ts
@@ -1,5 +1,4 @@
 import YoutubeHelper from "@vot.js/ext/helpers/youtube";
-import { getVideoData } from "@vot.js/ext/utils/videoData";
 import votConfig from "@vot.js/shared/config";
 import { availableLangs } from "@vot.js/shared/consts";
 import type { RequestLang, ResponseLang } from "@vot.js/shared/types/data";
@@ -16,6 +15,7 @@ import {
 import type { VideoHandler } from "../VideoHandler";
 import VOTLocalizedError from "../VOTLocalizedError";
 import type { VideoData as RuntimeVideoData } from "../videoHandler/shared";
+import { fetchSiteVideoData } from "./courseraVideoData";
 import { isExternalVolumeHost } from "./hostPolicies";
 import { detect } from "./translateApis";
 
@@ -444,7 +444,7 @@ export class VOTVideoManager {
       detectedLanguage: possibleLanguage,
       subtitles,
       isStream = false,
-    } = await getVideoData(this.videoHandler.site, {
+    } = await fetchSiteVideoData(this.videoHandler.site, {
       fetchFn: GM_fetch,
       video: this.videoHandler.video,
       language: localizationProvider.lang,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { bindObserverListeners } from "./bootstrap/videoObserverBinding";
 import { authServerUrl } from "./config/config";
 import { resolveBootstrapMode } from "./core/bootstrapPolicy";
 import { findConnectedContainerBySelector } from "./core/containerResolution";
+import { resolveSiteVideoId } from "./core/courseraVideoData";
 import debug from "./utils/debug";
 import { isIframe } from "./utils/iframeConnector";
 import { createIntervalIdleChecker } from "./utils/intervalIdleChecker";
@@ -122,6 +123,7 @@ async function main(): Promise<void> {
     findContainer,
     createVideoHandler: (video, container, site) =>
       new VideoHandler(video, container, site),
+    resolveVideoId: resolveSiteVideoId,
   });
   videoObserver.enable();
 }

--- a/src/videoHandler/modules/events.ts
+++ b/src/videoHandler/modules/events.ts
@@ -1,8 +1,8 @@
 import YoutubeHelper from "@vot.js/ext/helpers/youtube";
-import { getVideoID } from "@vot.js/ext/utils/videoData";
 import { availableLangs } from "@vot.js/shared/consts";
 import type { RequestLang } from "@vot.js/shared/types/data";
 import { defaultAutoHideDelay } from "../../config/config";
+import { resolveSiteVideoId } from "../../core/courseraVideoData";
 import {
   isDesktopYouTubeLikeSite,
   isMuteSyncDisabledHost,
@@ -12,7 +12,6 @@ import { resetAndHideLifecycle } from "../../core/lifecycleShared";
 import { getPlatformEventConfig } from "../../core/platformEvents";
 import debug from "../../utils/debug";
 import { containsCrossShadow, getDeepActiveElement } from "../../utils/dom";
-import { GM_fetch } from "../../utils/gm";
 import { isIframe } from "../../utils/iframeConnector";
 import { clampPercentInt } from "../../utils/volume";
 import type { VideoHandler } from "../../VideoHandler";
@@ -499,10 +498,7 @@ function bindVideoLifecycleEvents(ctx: ExtraEventsContext): void {
     emptiedHandled = true;
     let videoId: string | undefined;
     try {
-      videoId = await getVideoID(self.site, {
-        fetchFn: GM_fetch,
-        video: self.video,
-      });
+      videoId = await resolveSiteVideoId(self.site, self.video);
     } catch (error) {
       debug.log("[VOT] Failed to resolve video id on emptied", error);
     }

--- a/tests/coursera-support.test.ts
+++ b/tests/coursera-support.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getCourseraCourseSlugFromPath,
+  getCourseraVideoIdFromPath,
+} from "../src/core/courseraSupport";
+
+describe("getCourseraVideoIdFromPath", () => {
+  test("keeps the lecture id shape used by vot.js", () => {
+    expect(
+      getCourseraVideoIdFromPath(
+        "/learn/google-ai-for-app-building/lecture/iutP3/learn-how-to-build-a-custom-ai-tool",
+      ),
+    ).toBe("learn/google-ai-for-app-building/lecture/iutP3");
+  });
+
+  test("resolves ungraded lab instruction and workspace routes", () => {
+    const labId = "learn/google-ai-for-app-building/ungradedLab/SoZNK";
+
+    expect(
+      getCourseraVideoIdFromPath(
+        "/learn/google-ai-for-app-building/ungradedLab/SoZNK/build-with-ai-brand-builder-app-to-visualize-any-product",
+      ),
+    ).toBe(labId);
+    expect(
+      getCourseraVideoIdFromPath(
+        "/learn/google-ai-for-app-building/ungradedLab/SoZNK/build-with-ai-brand-builder-app-to-visualize-any-product/lab",
+      ),
+    ).toBe(labId);
+  });
+
+  test("resolves course preview lecture urls", () => {
+    expect(
+      getCourseraVideoIdFromPath(
+        "/lecture/learning-how-to-learn/welcome-to-the-course",
+      ),
+    ).toBe("lecture/learning-how-to-learn/welcome-to-the-course");
+  });
+
+  test("ignores course home paths without a video item id", () => {
+    expect(
+      getCourseraVideoIdFromPath(
+        "/learn/google-ai-for-app-building/home/week/1",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("getCourseraCourseSlugFromPath", () => {
+  test("reads the slug from lecture and lab routes", () => {
+    expect(
+      getCourseraCourseSlugFromPath(
+        "/learn/google-ai-for-app-building/lecture/iutP3/title",
+      ),
+    ).toBe("google-ai-for-app-building");
+    expect(
+      getCourseraCourseSlugFromPath(
+        "/learn/google-ai-for-app-building/ungradedLab/SoZNK/title/lab",
+      ),
+    ).toBe("google-ai-for-app-building");
+  });
+});


### PR DESCRIPTION
## Summary
- Coursera lectures already work, but ungraded labs with the same Video.js player never showed the VOT overlay. `@vot.js/ext` `CourseraHelper.getVideoId()` only matches `/lecture/`, so `videoLifecycleController` hid the overlay when `videoId` was missing.
- This patch parses `/ungradedLab/` and other on-demand item routes, keeps the same `learn/COURSE/ITEM_TYPE/ITEM_ID` shape, and routes Coursera through that helper in `resolveSiteVideoId` / `fetchSiteVideoData`.
- Verified on a logged-in lab page: https://www.coursera.org/learn/google-ai-for-app-building/ungradedLab/6Xiyw/build-with-ai-interactive-dashboard-to-uncover-data-insights/lab

A matching change in [FOSWLY/vot.js](https://github.com/FOSWLY/vot.js) (`packages/ext/src/helpers/coursera.ts`, `getVideoId` / `getCourseSlug`) would make this extension workaround unnecessary.

## Test plan
- [ ] Lecture still shows the overlay: `/learn/.../lecture/...`
- [ ] Ungraded lab shows the overlay: `/learn/.../ungradedLab/.../lab`
- [ ] Course home / week pages without a video item still do not show it
- [ ] `bun test tests/coursera-support.test.ts`


Made with [Cursor](https://cursor.com)